### PR TITLE
chore: deploy firefox addon via gh-pages

### DIFF
--- a/.github/workflows/deploy-update-manifest.yml
+++ b/.github/workflows/deploy-update-manifest.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright 2024 Siemens AG
+#
+# SPDX-License-Identifier: MPL-2.0
+name: Deploy Firefox Addon Update Manifest
+
+on:
+  push:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.pages/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.pages/firefox/updates.json
+++ b/.pages/firefox/updates.json
@@ -1,0 +1,13 @@
+{
+    "addons": {
+      "linux-entra-sso@example.com": {
+        "updates": [
+          {
+            "version": "0.6.1",
+            "update_link": "https://github.com/siemens/linux-entra-sso/releases/download/v0.6.1/linux_entra_sso-0.6.1.xpi",
+            "update_hash": "sha256:edb6d8b754d4c2390517815ed72f5a96f1394f322a555cf54f477ca5190562c1"
+          }
+        ]
+      }
+    }
+  }

--- a/.pages/firefox/updates.json.license
+++ b/.pages/firefox/updates.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Copyright 2024 Siemens AG
+
+SPDX-License-Identifier: MPL-2.0

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ sudo apt install python3-pydbus
 
 ## Installation
 
-### Firefox: via addons.mozilla.org
+### Firefox: Signed Version from Github Releases
 
-You can get a signed version of the browser extension from AMO (the Mozilla addons marketplace):
-[Linux Entra SSO](https://addons.mozilla.org/en-US/firefox/addon/linux-entra-sso/).
+You can get a signed version of the browser extension from our Github releases.
 As this only covers the browser part, the host tooling still needs to be installed manually:
 
 1. clone this repository

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -9,7 +9,8 @@
     "browser_specific_settings": {
         "gecko": {
             "id": "linux-entra-sso@example.com",
-            "strict_min_version": "109.0"
+            "strict_min_version": "109.0",
+            "update_url": "https://siemens.github.io/linux-entra-sso/firefox/updates.json"
         }
     },
     "action": {


### PR DESCRIPTION
The idea is to deploy the update manifest for Mozilla Firefox to github pages. On new releases, we create the release and build the (unsigned) xpi. Then, we upload that to AMO and wait for it to be signed. Once signed, we download the signed xpi and attach that to the release. Then, we update the update manifest and push that to main (which updates it on gh-pages as well). After that, all Firefox instances that have updates for this extension enabled will automatically download and updatethe extension.

closes: #5