### PR TITLE
fix: reset api token before requesting new

### DIFF
--- a/background.js
+++ b/background.js
@@ -58,10 +58,12 @@ async function load_accounts() {
     ssoLog('active account: ' + accounts.active.username);
 
     // load profile picture and set it as icon
-    graph_api_token = null;
-    port.postMessage({'command': 'acquireTokenSilently', 'account': accounts.active});
-    await waitFor(() => {return graph_api_token !== null; });
-    ssoLog('API token acquired');
+    if (!graph_api_token || graph_api_token.expiresOn < (Date.now() + 60000)) {
+        graph_api_token = null;
+        port.postMessage({'command': 'acquireTokenSilently', 'account': accounts.active});
+        await waitFor(() => {return graph_api_token !== null; });
+        ssoLog('API token acquired');
+    }
     const response = await fetch('https://graph.microsoft.com/v1.0/me/photos/48x48/$value', {
         headers: {
             'Content-Type': 'image/jpeg',

--- a/background.js
+++ b/background.js
@@ -58,6 +58,7 @@ async function load_accounts() {
     ssoLog('active account: ' + accounts.active.username);
 
     // load profile picture and set it as icon
+    graph_api_token = null;
     port.postMessage({'command': 'acquireTokenSilently', 'account': accounts.active});
     await waitFor(() => {return graph_api_token !== null; });
     ssoLog('API token acquired');


### PR DESCRIPTION
Before requesting a new API token, we need clear the variable that holds the current one, as this state is used as a synchronization point to wait for the token response.

This fixes issues, where the profile picture could not be loaded, because an outdated token was used.