### PR TITLE
ci: add manual approval step before release of update manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 # Sets permissions of the GITHUB_TOKEN to checkout the repository
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   WEB_EXT_VERS: 8.2.0
@@ -22,6 +23,10 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+
+      - name: get git committer
+        run: |
+          echo "GIT_COMMITTER=$(git show -s --format='%cn <%ce>')" >> $GITHUB_ENV
 
       - name: install dependencies
         run: |
@@ -67,10 +72,18 @@ jobs:
             .pages/firefox/updates.json \
             > .pages/firefox/updates.json.tmp && mv .pages/firefox/updates.json.tmp .pages/firefox/updates.json
 
-      - name: commit update manifest for Firefox
-        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
+      - name: prepare PR for Firefox update manifest
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
-          commit_message: "chore: release Firefox update manifest"
-          commit_user_name: "${{ github.actor }} [bot]"
-          branch: main
-          file_pattern: '.pages/firefox/updates.json'
+          add-paths: '.pages/firefox/updates.json'
+          commit-message: "chore: release Firefox update manifest"
+          branch: ci/release-firefox-update-manifest
+          base: main
+          title: "chore: release Firefox update manifest [bot]"
+          assignees: fmoessbauer
+          reviewers: jan-kiszka
+          author: ${{ env.GIT_COMMITTER }}
+          committer: ${{ env.GIT_COMMITTER }}
+          signoff: true
+          body: |
+            Publish update manifest for Firefox extension, version ${{ github.ref_name }}.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,5 @@ The creation of public releases is a partially automated process:
 2. push to GitHub: `git push origin main && git push origin v<x.x.x>`
 3. wait for release action to finish (public release is created)
 4. add release-notes to public release
+5. manually inspect signed xpi (double check)
+6. merge auto-created MR to enroll Firefox update manifest


### PR DESCRIPTION
Previously we automatically committed the update manifest to the main branch after the release was created. This approach had two issues:

- no option to manually inspect xpi file before rollout
- main branch cannot be protected (limited to maintainer-only)

This patch replaces this auto-commit with a pull request based workflow, where the CI action just creates a MR, but this has to be manually merged.