### PR TITLE
Add listing on Chrome Web Store and support to package host parts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   WEB_EXT_VERS: 8.2.0
 
 jobs:
-  release-xpi:
+  release-extension:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
@@ -88,3 +88,13 @@ jobs:
           signoff: true
           body: |
             Publish update manifest for Firefox extension, version ${{ github.ref_name }}.
+
+      - name: release Chrome extension on CWS
+        uses: mnao305/chrome-extension-upload@4008e29e13c144d0f6725462cbd49b7c291b4928 # v5.0.0
+        with:
+          file-path: build/Linux-Entra-SSO-*chrome.zip
+          glob: true
+          extension-id: jlnfnnolkbjieggibinobhkjdfbpcohn
+          client-id: ${{ secrets.CWS_CLIENT_ID }}
+          client-secret: ${{ secrets.CWS_CLIENT_SECRET }}
+          refresh-token: ${{ secrets.CWS_REFRESH_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,3 @@ The creation of public releases is a partially automated process:
 4. add release-notes to public release
 5. manually inspect signed xpi (double check)
 6. merge auto-created MR to enroll Firefox update manifest
-
-Further, the extension needs to be manually updated on the Chrome Web Store:
-
-1. Login on the [Chrome Web Store Developer Console](https://chrome.google.com/webstore/devconsole/)
-2. Select `Linux Entra SSO` extension
-3. Go to `Package` and click `Upload New Package` (upload the `.zip` file)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,9 @@ The creation of public releases is a partially automated process:
 4. add release-notes to public release
 5. manually inspect signed xpi (double check)
 6. merge auto-created MR to enroll Firefox update manifest
+
+Further, the extension needs to be manually updated on the Chrome Web Store:
+
+1. Login on the [Chrome Web Store Developer Console](https://chrome.google.com/webstore/devconsole/)
+2. Select `Linux Entra SSO` extension
+3. Go to `Package` and click `Upload New Package` (upload the `.zip` file)

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ release:
 local-install-firefox:
 	install -d ~/.mozilla/native-messaging-hosts
 	install -m 0644 platform/firefox/linux_entra_sso.json ~/.mozilla/native-messaging-hosts
-	sed -i 's|/usr/local/lib/mozilla/|'$(HOME)'/.mozilla/|' ~/.mozilla/native-messaging-hosts/linux_entra_sso.json
+	sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.mozilla/|' ~/.mozilla/native-messaging-hosts/linux_entra_sso.json
 	install -m 0755 linux-entra-sso.py ~/.mozilla
 
 local-install-chrome:
@@ -102,14 +102,36 @@ local-install-chrome:
 	install -d ~/.config/chromium/NativeMessagingHosts
 	install -m 0644 platform/chrome/linux_entra_sso.json ~/.config/google-chrome/NativeMessagingHosts
 	install -m 0644 platform/chrome/linux_entra_sso.json ~/.config/chromium/NativeMessagingHosts
-	sed -i 's|/usr/local/lib/chrome/|'$(HOME)'/.config/google-chrome/|' ~/.config/google-chrome/NativeMessagingHosts/linux_entra_sso.json
-	sed -i 's|/usr/local/lib/chrome/|'$(HOME)'/.config/google-chrome/|' ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
+	sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.config/google-chrome/|' ~/.config/google-chrome/NativeMessagingHosts/linux_entra_sso.json
+	sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.config/google-chrome/|' ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
 	# compute extension id and and grant permission
 	sed -i 's|{extension_id}|$(CHROME_EXT_ID)|' ~/.config/google-chrome/NativeMessagingHosts/linux_entra_sso.json
 	sed -i 's|{extension_id}|$(CHROME_EXT_ID)|' ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
 	install -m 0755 linux-entra-sso.py ~/.config/google-chrome
 
 local-install: local-install-firefox local-install-chrome
+
+install:
+	# Host application
+	install -d $(DESTDIR)/usr/local/lib/linux-entra-sso
+	install -m 0755 linux-entra-sso.py $(DESTDIR)/usr/local/lib/linux-entra-sso
+	# Firefox
+	install -d $(DESTDIR)/usr/lib/mozilla/native-messaging-hosts
+	install -m 0644 platform/firefox/linux_entra_sso.json $(DESTDIR)/usr/lib/mozilla/native-messaging-hosts
+	# Chrome
+	install -d $(DESTDIR)/etc/opt/chrome/native-messaging-hosts
+	install -m 0644 platform/chrome/linux_entra_sso.json $(DESTDIR)/etc/opt/chrome/native-messaging-hosts
+	sed -i '/{extension_id}/d' $(DESTDIR)/etc/opt/chrome/native-messaging-hosts/linux_entra_sso.json
+	# Chromium
+	install -d $(DESTDIR)/etc/chromium/native-messaging-hosts
+	install -m 0644 platform/chrome/linux_entra_sso.json $(DESTDIR)/etc/chromium/native-messaging-hosts
+	sed -i '/{extension_id}/d' $(DESTDIR)/etc/chromium/native-messaging-hosts/linux_entra_sso.json
+
+uninstall:
+	rm -rf $(DESTDIR)/usr/local/lib/linux-entra-sso
+	rm -f  $(DESTDIR)/usr/lib/mozilla/native-messaging-hosts/linux_entra_sso.json
+	rm -f  $(DESTDIR)/etc/opt/chrome/native-messaging-hosts/linux_entra_sso.json
+	rm -f  $(DESTDIR)/etc/chromium/native-messaging-hosts/linux_entra_sso.json
 
 local-uninstall-firefox:
 	rm -f ~/.mozilla/native-messaging-hosts/linux_entra_sso.json ~/.mozilla/linux-entra-sso.py
@@ -120,4 +142,4 @@ local-uninstall-chrome:
 
 local-uninstall: local-uninstall-firefox local-uninstall-chrome
 
-.PHONY: clean release local-install-firefox local-install-chrome local-install local-uninstall-firefox local-uninstall-chrome local-uninstall
+.PHONY: clean release local-install-firefox local-install-chrome local-install install local-uninstall-firefox local-uninstall-chrome local-uninstall uninstall

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,8 @@ local-install-chrome:
 	sed -i 's|{extension_id}|$(CHROME_EXT_ID)|' ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
 	install -m 0755 linux-entra-sso.py ~/.config/google-chrome
 
+local-install: local-install-firefox local-install-chrome
+
 local-uninstall-firefox:
 	rm -f ~/.mozilla/native-messaging-hosts/linux_entra_sso.json ~/.mozilla/linux-entra-sso.py
 
@@ -116,4 +118,6 @@ local-uninstall-chrome:
 	rm -f ~/.config/google-chrome/NativeMessagingHosts/linux_entra_sso.json ~/.config/google-chrome/linux-entra-sso.py
 	rm -f ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
 
-.PHONY: clean release local-install-firefox local-install-chrome local-uninstall-firefox local-uninstall-chrome
+local-uninstall: local-uninstall-firefox local-uninstall-chrome
+
+.PHONY: clean release local-install-firefox local-install-chrome local-install local-uninstall-firefox local-uninstall-chrome local-uninstall

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ As this only covers the browser part, the host tooling still needs to be install
 2. run `make local-install-firefox`
 3. Enable "Access your data for https://login.microsoftonline.com" under the extension's permissions
 
+### Chrome: Signed Version from Chrome Web Store
+
+You can get a signed version of the browser extension from the Chrome Web Store.
+As this only covers the browser part, the host tooling still needs to be installed manually:
+
+1. clone this repository
+2. run `make local-install-chrome`
+3. Install the [linux-entra-sso](https://chrome.google.com/webstore/detail/jlnfnnolkbjieggibinobhkjdfbpcohn) Chrome extension from the Chrome Web Store
+
 ### Development Version and Other Browsers
 
 If you want to execute unsigned versions of the extension (e.g. test builds) on Firefox, you have to use either Firefox ESR,

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ To build the extension and install the host parts, perform the following steps:
 5. Install the extension in the Browser from the local `linux-entra-sso-*.xpi` file (Firefox). On Chrome, use `load unpacked` and point to `build/chrome`
 6. Enable "Access your data for https://login.microsoftonline.com" under the extension's permissions
 
+### Global Installation of Host Components
+
+Linux distributions can ship the host components by packaging the output of `make install` (`DESTDIR` is supported).
+This makes the host parts available to all users, but will only work with the signed versions of the extension.
+Note, that the users still need to manually install the browser extension from the respective stores.
+
 ## Usage
 
 No configuration is required. However, you might need to clear all cookies on

--- a/platform/chrome/linux_entra_sso.json
+++ b/platform/chrome/linux_entra_sso.json
@@ -1,7 +1,7 @@
 {
     "name": "linux_entra_sso",
     "description": "Entra ID SSO via Microsoft Identity Broker",
-    "path": "/usr/local/lib/chrome/linux-entra-sso.py",
+    "path": "/usr/local/lib/linux-entra-sso/linux-entra-sso.py",
     "type": "stdio",
     "allowed_origins": [
         "chrome-extension://{extension_id}/",

--- a/platform/chrome/linux_entra_sso.json
+++ b/platform/chrome/linux_entra_sso.json
@@ -4,6 +4,7 @@
     "path": "/usr/local/lib/chrome/linux-entra-sso.py",
     "type": "stdio",
     "allowed_origins": [
-        "chrome-extension://{extension_id}/"
+        "chrome-extension://{extension_id}/",
+        "chrome-extension://jlnfnnolkbjieggibinobhkjdfbpcohn/"
     ]
 }

--- a/platform/firefox/linux_entra_sso.json
+++ b/platform/firefox/linux_entra_sso.json
@@ -1,7 +1,7 @@
 {
     "name": "linux_entra_sso",
     "description": "Entra ID SSO via Microsoft Identity Broker",
-    "path": "/usr/local/lib/mozilla/linux-entra-sso.py",
+    "path": "/usr/local/lib/linux-entra-sso/linux-entra-sso.py",
     "type": "stdio",
     "allowed_extensions": [
         "linux-entra-sso@example.com"


### PR DESCRIPTION
As we finally have the extension published on the Chrome Web Store (unlisted currently), we can also install the host parts globally. By that, a (inhouse) Linux distro can package the host parts and enroll them. Then, the users only need to install the web extension from the browser extension stores.