### PR TITLE
feat: pre-register extension on Chrome

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ FIREFOX_PACKAGE_FILES= \
 UPDATE_VERSION='s|"version":.*|"version": "$(VERSION)",|'
 
 CHROME_EXT_ID=$(shell $(CURDIR)/platform/chrome/get-ext-id.py $(CURDIR)/build/chrome/)
+CHROME_EXT_ID_SIGNED=jlnfnnolkbjieggibinobhkjdfbpcohn
 
 all package: clean $(CHROME_INPUT_FILES) $(FIREFOX_INPUT_FILES)
 	for P in firefox chrome; do \
@@ -122,6 +123,8 @@ install:
 	install -d $(DESTDIR)/etc/opt/chrome/native-messaging-hosts
 	install -m 0644 platform/chrome/linux_entra_sso.json $(DESTDIR)/etc/opt/chrome/native-messaging-hosts
 	sed -i '/{extension_id}/d' $(DESTDIR)/etc/opt/chrome/native-messaging-hosts/linux_entra_sso.json
+	install -d $(DESTDIR)/usr/share/google-chrome/extensions
+	install -m 0644 platform/chrome/extension.json $(DESTDIR)/usr/share/google-chrome/extensions/$(CHROME_EXT_ID_SIGNED).json
 	# Chromium
 	install -d $(DESTDIR)/etc/chromium/native-messaging-hosts
 	install -m 0644 platform/chrome/linux_entra_sso.json $(DESTDIR)/etc/chromium/native-messaging-hosts
@@ -132,6 +135,7 @@ uninstall:
 	rm -f  $(DESTDIR)/usr/lib/mozilla/native-messaging-hosts/linux_entra_sso.json
 	rm -f  $(DESTDIR)/etc/opt/chrome/native-messaging-hosts/linux_entra_sso.json
 	rm -f  $(DESTDIR)/etc/chromium/native-messaging-hosts/linux_entra_sso.json
+	rm -f  $(DESTDIR)/usr/share/google-chrome/extensions/$(CHROME_EXT_ID_SIGNED).json
 
 local-uninstall-firefox:
 	rm -f ~/.mozilla/native-messaging-hosts/linux_entra_sso.json ~/.mozilla/linux-entra-sso.py

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ To build the extension and install the host parts, perform the following steps:
 
 Linux distributions can ship the host components by packaging the output of `make install` (`DESTDIR` is supported).
 This makes the host parts available to all users, but will only work with the signed versions of the extension.
-Note, that the users still need to manually install the browser extension from the respective stores.
+On Chrome, the extension is registered to be auto-installed when starting the browser.
+On Firefox and Chromium, the users still need to manually install the browser extension from the respective stores.
 
 ## Usage
 

--- a/platform/chrome/extension.json
+++ b/platform/chrome/extension.json
@@ -1,0 +1,3 @@
+{
+    "external_update_url": "https://clients2.google.com/service/update2/crx"
+}

--- a/platform/chrome/extension.json.license
+++ b/platform/chrome/extension.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Copyright 2024 Siemens AG
+
+SPDX-License-Identifier: MPL-2.0


### PR DESCRIPTION
By pre-registering the extension on Chrome on install, the browser automatically downloads and installs the latest version of the extension on startup. By that, we can prepare both the host and the browser part for Chrome and ship that as part of the distribution.