### PR TITLE
docs: improve documentation around how to install on FF

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ As this only covers the browser part, the host tooling still needs to be install
 
 1. clone this repository
 2. run `make local-install-firefox`
-3. Enable "Access your data for https://login.microsoftonline.com" under the extension's permissions
+3. Get the `linux_entra_sso-<version>.xpi` file from the [project's releases page](https://github.com/siemens/linux-entra-sso/releases)
+4. Enable "Access your data for https://login.microsoftonline.com" under the extension's permissions
 
 ### Chrome: Signed Version from Chrome Web Store
 


### PR DESCRIPTION
The documentation did not mention to get the signed .xpi file form the github releases page. This patch makes this point more clear.

cc @romanho

closes: #18