### PR TITLE
docs: add note to upload .crx to release, once signed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,4 @@ The creation of public releases is a partially automated process:
 4. add release-notes to public release
 5. manually inspect signed xpi (double check)
 6. merge auto-created MR to enroll Firefox update manifest
+7. wait for CWS to review and sign extension, upload `.crx` to releases page


### PR DESCRIPTION
Once the chrome / chromium version of the extension is signed, we need to download it from the store and upload to the releases. As this step is tricky to automate, we just document it for now.

cc @rutgerputter