### PR TITLE
chore: check if broker is running before starting

### DIFF
--- a/linux-entra-sso.py
+++ b/linux-entra-sso.py
@@ -82,7 +82,8 @@ class SsoMib:
 
     def _check_broker_online(self):
         dbus = self._bus.get('org.freedesktop.DBus', '/org/freedesktop/DBus')
-        if dbus.StartServiceByName(self.BROKER_NAME, 0) in \
+        if dbus.NameHasOwner(self.BROKER_NAME) \
+            or dbus.StartServiceByName(self.BROKER_NAME, 0) in \
                 [START_REPLY_ALREADY_RUNNING, START_REPLY_SUCCESS]:
             self._instantiate_broker()
             self.broker_online = True


### PR DESCRIPTION
In case the identity broker is not registered as systemd service, we cannot start it. This however is also not needed, as long as the service is visible on the bus.

This patch changes the logic to check for a running broker by first checking if it is running and only if not starting it.