### PR TITLE
feat: show plugin versions in menu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Copyright 2024 Siemens AG
 SPDX-License-Identifier: MPL-2.0
 -->
 
-# Contributing to browser-intune-plugin
+# Contributing to linux-entra-sso
 
 Contributions are always welcome. This document explains the
 general requirements on contributions and the recommended preparation

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ endif
 PACKAGE_NAME=Linux-Entra-SSO
 
 RELEASE_TAG ?= $(shell git describe --match "v[0-9].[0-9]*" --dirty)
+WEBEXT_VERSION=$(shell echo $(RELEASE_TAG) | sed -e s:^v::)
 ARCHIVE_NAME=$(PACKAGE_NAME)-$(RELEASE_TAG)
 
 COMMON_INPUT_FILES= \
@@ -80,6 +81,7 @@ FIREFOX_PACKAGE_FILES= \
 	popup/profile-outline.svg
 
 UPDATE_VERSION='s|"version":.*|"version": "$(VERSION)",|'
+UPDATE_VERSION_PY='s|0.0.0-dev|$(WEBEXT_VERSION)|g'
 
 CHROME_EXT_ID=$(shell $(CURDIR)/platform/chrome/get-ext-id.py $(CURDIR)/build/chrome/)
 CHROME_EXT_ID_SIGNED=jlnfnnolkbjieggibinobhkjdfbpcohn
@@ -149,6 +151,7 @@ local-install-firefox:
 	install -m 0644 platform/firefox/linux_entra_sso.json ~/.mozilla/native-messaging-hosts
 	sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.mozilla/|' ~/.mozilla/native-messaging-hosts/linux_entra_sso.json
 	install -m 0755 linux-entra-sso.py ~/.mozilla
+	${Q}sed -i $(UPDATE_VERSION_PY) ~/.mozilla/linux-entra-sso.py
 
 local-install-chrome:
 	install -d ~/.config/google-chrome/NativeMessagingHosts
@@ -161,6 +164,7 @@ local-install-chrome:
 	sed -i 's|{extension_id}|$(CHROME_EXT_ID)|' ~/.config/google-chrome/NativeMessagingHosts/linux_entra_sso.json
 	sed -i 's|{extension_id}|$(CHROME_EXT_ID)|' ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
 	install -m 0755 linux-entra-sso.py ~/.config/google-chrome
+	${Q}sed -i $(UPDATE_VERSION_PY) ~/.config/google-chrome/linux-entra-sso.py
 
 local-install: local-install-firefox local-install-chrome
 
@@ -168,6 +172,7 @@ install:
 	# Host application
 	install -d $(DESTDIR)/$(libexecdir)/linux-entra-sso
 	install -m 0755 linux-entra-sso.py $(DESTDIR)/$(libexecdir)/linux-entra-sso
+	${Q}sed -i $(UPDATE_VERSION_PY) $(DESTDIR)/$(libexecdir)/linux-entra-sso/linux-entra-sso.py
 	# Firefox
 	install -d $(DESTDIR)/$(firefox_nm_dir)
 	install -m 0644 platform/firefox/linux_entra_sso.json $(DESTDIR)/$(firefox_nm_dir)

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ release:
 local-install-firefox:
 	install -d ~/.mozilla/native-messaging-hosts
 	install -m 0644 platform/firefox/linux_entra_sso.json ~/.mozilla/native-messaging-hosts
-	sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.mozilla/|' ~/.mozilla/native-messaging-hosts/linux_entra_sso.json
+	${Q}sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.mozilla/|' ~/.mozilla/native-messaging-hosts/linux_entra_sso.json
 	install -m 0755 linux-entra-sso.py ~/.mozilla
 	${Q}sed -i $(UPDATE_VERSION_PY) ~/.mozilla/linux-entra-sso.py
 
@@ -158,11 +158,11 @@ local-install-chrome:
 	install -d ~/.config/chromium/NativeMessagingHosts
 	install -m 0644 platform/chrome/linux_entra_sso.json ~/.config/google-chrome/NativeMessagingHosts
 	install -m 0644 platform/chrome/linux_entra_sso.json ~/.config/chromium/NativeMessagingHosts
-	sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.config/google-chrome/|' ~/.config/google-chrome/NativeMessagingHosts/linux_entra_sso.json
-	sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.config/google-chrome/|' ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
+	${Q}sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.config/google-chrome/|' ~/.config/google-chrome/NativeMessagingHosts/linux_entra_sso.json
+	${Q}sed -i 's|/usr/local/lib/linux-entra-sso/|'$(HOME)'/.config/google-chrome/|' ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
 	# compute extension id and and grant permission
-	sed -i 's|{extension_id}|$(CHROME_EXT_ID)|' ~/.config/google-chrome/NativeMessagingHosts/linux_entra_sso.json
-	sed -i 's|{extension_id}|$(CHROME_EXT_ID)|' ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
+	${Q}sed -i 's|{extension_id}|$(CHROME_EXT_ID)|' ~/.config/google-chrome/NativeMessagingHosts/linux_entra_sso.json
+	${Q}sed -i 's|{extension_id}|$(CHROME_EXT_ID)|' ~/.config/chromium/NativeMessagingHosts/linux_entra_sso.json
 	install -m 0755 linux-entra-sso.py ~/.config/google-chrome
 	${Q}sed -i $(UPDATE_VERSION_PY) ~/.config/google-chrome/linux-entra-sso.py
 
@@ -176,19 +176,19 @@ install:
 	# Firefox
 	install -d $(DESTDIR)/$(firefox_nm_dir)
 	install -m 0644 platform/firefox/linux_entra_sso.json $(DESTDIR)/$(firefox_nm_dir)
-	sed -i 's|/usr/local/lib/|'$(libexecdir)/'|' $(DESTDIR)/$(firefox_nm_dir)/linux_entra_sso.json
+	${Q}sed -i 's|/usr/local/lib/|'$(libexecdir)/'|' $(DESTDIR)/$(firefox_nm_dir)/linux_entra_sso.json
 	# Chrome
 	install -d $(DESTDIR)/$(chrome_nm_dir)
 	install -m 0644 platform/chrome/linux_entra_sso.json $(DESTDIR)/$(chrome_nm_dir)
-	sed -i 's|/usr/local/lib/|'$(libexecdir)/'|' $(DESTDIR)/$(chrome_nm_dir)/linux_entra_sso.json
-	sed -i '/{extension_id}/d' $(DESTDIR)/$(chrome_nm_dir)/linux_entra_sso.json
+	${Q}sed -i 's|/usr/local/lib/|'$(libexecdir)/'|' $(DESTDIR)/$(chrome_nm_dir)/linux_entra_sso.json
+	${Q}sed -i '/{extension_id}/d' $(DESTDIR)/$(chrome_nm_dir)/linux_entra_sso.json
 	install -d $(DESTDIR)/$(chrome_ext_dir)
 	install -m 0644 platform/chrome/extension.json $(DESTDIR)/$(chrome_ext_dir)/$(CHROME_EXT_ID_SIGNED).json
 	# Chromium
 	install -d $(DESTDIR)/$(chromium_nm_dir)
 	install -m 0644 platform/chrome/linux_entra_sso.json $(DESTDIR)/$(chromium_nm_dir)
-	sed -i 's|/usr/local/lib/|'$(libexecdir)/'|' $(DESTDIR)/$(chromium_nm_dir)/linux_entra_sso.json
-	sed -i '/{extension_id}/d' $(DESTDIR)/$(chromium_nm_dir)/linux_entra_sso.json
+	${Q}sed -i 's|/usr/local/lib/|'$(libexecdir)/'|' $(DESTDIR)/$(chromium_nm_dir)/linux_entra_sso.json
+	${Q}sed -i '/{extension_id}/d' $(DESTDIR)/$(chromium_nm_dir)/linux_entra_sso.json
 
 uninstall:
 	rm -rf $(DESTDIR)/$(libexecdir)/linux-entra-sso

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ The provided defaults work on a Debian system. For details, have a look at the M
 
 ## Usage
 
-No configuration is required. However, you might need to clear all cookies on
+No configuration is required. The SSO is automatically enabled.
+If you want to disable the SSO for this session, click on the tray icon and select the guest account.
+
+However, you might need to clear all cookies on
 `login.microsoftonline.com`, in case you are already logged. The extension
 will automatically acquire a [PRT SSO Cookie](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oapxbc/105e4d17-defd-4637-a520-173db2393a4b)
 from the locally running device identity broker and inject that into the OAuth2 login workflow for all Microsoft Entra ID enabled sites

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: MPL-2.0
 
 # Entra ID SSO via Microsoft Identity Broker on Linux
 
-This browser plugin uses a locally running Microsoft Identity Broker to authenticate the current user on Microsoft Entra ID on Linux devices.
+This browser extension uses a locally running Microsoft Identity Broker to authenticate the current user on Microsoft Entra ID on Linux devices.
 By that, also sites behind conditional access policies can be accessed.
-The plugin is written for Firefox but provides a limited support for Google Chrome (and Chromium).
+The extension is written for Firefox but provides a limited support for Google Chrome (and Chromium).
 
 ## Pre-conditions
 
@@ -50,7 +50,7 @@ As this only covers the browser part, the host tooling still needs to be install
 ### Development Version and Other Browsers
 
 If you want to execute unsigned versions of the extension (e.g. test builds) on Firefox, you have to use either Firefox ESR,
-nightly or developer, as [standard Firefox does not allow installing unsigned plugins](https://support.mozilla.org/en-US/kb/add-on-signing-in-firefox#w_what-are-my-options-if-i-want-to-use-an-unsigned-add-on-advanced-users)
+nightly or developer, as [standard Firefox does not allow installing unsigned extensions](https://support.mozilla.org/en-US/kb/add-on-signing-in-firefox#w_what-are-my-options-if-i-want-to-use-an-unsigned-add-on-advanced-users)
 since version 48.
 
 To build the extension and install the host parts, perform the following steps:
@@ -95,7 +95,7 @@ As the SNAP executes Firefox inside a container, the communication with DBus wil
 
 ### Expired Tokens on Chrome
 
-Due to not having the WebRequestsBlocking API on Chrome, the plugin needs to use a different mechanism to inject the token.
+Due to not having the WebRequestsBlocking API on Chrome, the extension needs to use a different mechanism to inject the token.
 While in Firefox the token is requested on-demand when hitting the SSO login URL, in Chrome the token is requested periodically.
 Then, a declarativeNetRequest API rule is setup to inject the token. As the lifetime of the tokens is limited and cannot be checked,
 outdated tokens might be injected. Further, a generic SSO URL must be used when requesting the token, instead of the actual one.

--- a/README.md
+++ b/README.md
@@ -16,17 +16,10 @@ check this by running the `intune-portal` application and check if your user
 is logged in (after clicking `sign-in`).
 Also make sure to install the host components (see *Installation* below).
 
-## Dependencies
-
-The extension requires pydbus as a runtime dependency. On a Debian system please install `python3-pydbus`:
-
-```bash
-sudo apt install python3-pydbus
-```
-
-**Note:** If you are using a python version manager such as asdf you must install the python packages manually: `pip install PyGObject pydbus`
-
 ## Installation
+
+The extension requires pydbus as a runtime dependency. On a Debian system please install `python3-pydbus`.
+If you are using a python version manager such as `asdf` you must install the python packages manually: `pip install PyGObject pydbus`
 
 ### Firefox: Signed Version from Github Releases
 
@@ -36,7 +29,7 @@ As this only covers the browser part, the host tooling still needs to be install
 1. clone this repository
 2. run `make local-install-firefox`
 3. Get the `linux_entra_sso-<version>.xpi` file from the [project's releases page](https://github.com/siemens/linux-entra-sso/releases)
-4. Enable "Access your data for https://login.microsoftonline.com" under the extension's permissions
+4. Enable "Access your data for `https://login.microsoftonline.com`" under the extension's permissions
 
 ### Chrome: Signed Version from Chrome Web Store
 
@@ -61,7 +54,7 @@ To build the extension and install the host parts, perform the following steps:
 4. Firefox only: Permit unsigned extensions in Firefox by setting `xpinstall.signatures.required` to `false`
 4. Chrome only: In extension menu, enable `Developer mode`.
 5. Install the extension in the Browser from the local `linux-entra-sso-*.xpi` file (Firefox). On Chrome, use `load unpacked` and point to `build/chrome`
-6. Enable "Access your data for https://login.microsoftonline.com" under the extension's permissions
+6. Enable "Access your data for `https://login.microsoftonline.com`" under the extension's permissions
 
 ### Global Installation of Host Components
 
@@ -76,28 +69,28 @@ The provided defaults work on a Debian system. For details, have a look at the M
 
 ## Usage
 
-No configuration is required. The SSO is automatically enabled.
+**No configuration is required.** The SSO is automatically enabled.
 If you want to disable the SSO for this session, click on the tray icon and select the guest account.
+In case you are already logged in, you might need to clear all cookies on `login.microsoftonline.com`.
 
-However, you might need to clear all cookies on
-`login.microsoftonline.com`, in case you are already logged. The extension
-will automatically acquire a [PRT SSO Cookie](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oapxbc/105e4d17-defd-4637-a520-173db2393a4b)
-from the locally running device identity broker and inject that into the OAuth2 login workflow for all Microsoft Entra ID enabled sites
-(the ones you log in via `login.microsoftonline.com`).
+### Technical Background
+
+When enabled, the extension acquires a [PRT SSO Cookie](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oapxbc/105e4d17-defd-4637-a520-173db2393a4b)
+from the locally running `microsoft-identity-broker` service and inject that into the OAuth2 login flow on Microsoft Entra ID (`login.microsoftonline.com`).
 
 ## Known Limitations
 
 ### SNAP version not supported
 
 This extension will not work on the snap version of Firefox.
-The extension executes a script `linux-entra-sso.py` on the host that communicates via DBus with the `microsoft-identity-broker` service.
-As the SNAP executes Firefox inside a container, the communication with DBus will not work. Please use the `firefox-esr` Debian package instead.
+The extension executes a script `linux-entra-sso.py` on the host that communicates via D-Bus with the `microsoft-identity-broker` service.
+As the SNAP executes Firefox inside a container, the communication with D-Bus will not work. Please use the `firefox-esr` Debian package instead.
 
 ### Expired Tokens on Chrome
 
-Due to not having the WebRequestsBlocking API on Chrome, the extension needs to use a different mechanism to inject the token.
+Due to not having the `WebRequestsBlocking` API on Chrome, the extension needs to use a different mechanism to inject the token.
 While in Firefox the token is requested on-demand when hitting the SSO login URL, in Chrome the token is requested periodically.
-Then, a declarativeNetRequest API rule is setup to inject the token. As the lifetime of the tokens is limited and cannot be checked,
+Then, a `declarativeNetRequest` API rule is setup to inject the token. As the lifetime of the tokens is limited and cannot be checked,
 outdated tokens might be injected. Further, a generic SSO URL must be used when requesting the token, instead of the actual one.
 
 ## Troubleshooting

--- a/linux-entra-sso.py
+++ b/linux-entra-sso.py
@@ -187,7 +187,7 @@ class SsoMib:
         return resp
 
 
-def run_as_plugin():
+def run_as_native_messaging():
     iomutex = Lock()
 
     def respond(command, message):
@@ -209,11 +209,11 @@ def run_as_plugin():
         libc = ctypes.CDLL("libc.so.6")
         libc.prctl(PR_SET_PDEATHSIG, SIGINT, 0, 0, 0)
 
-    print("Running as browser plugin.", file=sys.stderr)
+    print("Running as native messaging instance.", file=sys.stderr)
     print("For interactive mode, start with --interactive", file=sys.stderr)
 
     # on chrome and chromium, the parent process does not reliably
-    # terminate the plugin process when the parent process is killed.
+    # terminate the process when the parent process is killed.
     register_terminate_with_parent()
 
     ssomib = SsoMib(daemon=True)
@@ -286,4 +286,4 @@ if __name__ == '__main__':
     if '--interactive' in sys.argv or '-i' in sys.argv:
         run_interactive()
     else:
-        run_as_plugin()
+        run_as_native_messaging()

--- a/popup/menu.js
+++ b/popup/menu.js
@@ -51,6 +51,14 @@ bg_port.onMessage.addListener(async (m) => {
             document.getElementById("entity-guest").classList.add("active");
             active = false;
         }
+        if (m.host_version && m.broker_version) {
+            let pvers = chrome.runtime.getManifest().version;
+            let vstr = "v" + pvers;
+            if (m.host_version !== pvers) {
+                vstr += " (host v" + m.host_version + ")";
+            }
+            document.getElementById("version").innerHTML = vstr;
+        }
     }
 });
 
@@ -64,4 +72,3 @@ document.getElementById("entity-guest").addEventListener("click", (event) => {
     if (!set_inflight(this)) return;
     bg_port.postMessage({ command: "disable"});
 });
-document.getElementById("version").innerHTML = "v" + chrome.runtime.getManifest().version;


### PR DESCRIPTION
When updating the browser plugin via the app stores, the host version might get out of sync with the web extension version.

To notify the user about this, we add an endpoint (API call) to query version information of the host tooling. In case it does not match we show both versions in the UI. Later on, we can define version boundaries and show a more prominent warning. For now, this is not needed as we are 100% compatible with the first released version.