### PR TITLE
Workaround for incorrect DBus activation

### DIFF
--- a/background.js
+++ b/background.js
@@ -51,7 +51,7 @@ async function waitFor(f) {
  * Check if all conditions for SSO are met
  */
 function is_operational() {
-    return state_active && accounts.active && broker_online
+    return state_active && accounts.active
 }
 
 /*
@@ -327,12 +327,14 @@ async function on_message_native(response) {
         if (response.message == 'online') {
             ssoLog('connection to broker restored');
             broker_online = true;
-            await load_accounts();
-            port_native.postMessage({'command': 'getVersion'});
+            // only reload data if we did not see the broker before
+            if (host_versions.native === null) {
+                await load_accounts();
+                port_native.postMessage({'command': 'getVersion'});
+            }
         } else {
             ssoLog('lost connection to broker');
             broker_online = false;
-            logout();
         }
     }
     else {


### PR DESCRIPTION
The broker implements DBus activation. However, it appears on the bus before it can fully be used (i.e. before the `/com/microsoft/identity/broker1` becomes visible). By that, the buffered API calls are dispatched too early and return with an UnknownObject
error. This affects both the introspection and API calls.

To work around this, we poll for the path to show up before performing any other broker communication. Once the broker disappears, we clear our internal state to ensure the polling happens again before the next invocation.

Closes: #33 
