### PR TITLE
ci: use fine-grained job-token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,6 @@ on:
 # Sets permissions of the GITHUB_TOKEN to checkout the repository
 permissions:
   contents: read
-  id-token: write
-  attestations: write
 
 env:
   WEB_EXT_VERS: 8.2.0
@@ -42,6 +40,9 @@ jobs:
 
   build-xpi:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - name: checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-update-manifest.yml
+++ b/.github/workflows/deploy-update-manifest.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -20,6 +18,9 @@ concurrency:
 
 jobs:
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,18 @@ on:
       - 'v*.*'
       - 'v*.*.*'
 
-# Sets permissions of the GITHUB_TOKEN to checkout the repository
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
-  attestations: write
+permissions: {}
 
 env:
   WEB_EXT_VERS: 8.2.0
 
 jobs:
   release-extension:
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository


### PR DESCRIPTION
Not much changes, but splitting the global workflow permissions from the job permissions is best practice.