### PR TITLE
chore(deb): add python3-gi as explicit dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ deb:
 		echo Priority: optional; \
 		echo 'Maintainer: Dr. Johann Pfefferl <johann.pfefferl@siemens.com>'; \
 		echo Installed-Size: `du --summarize $(DEBIAN_DESTDIR) | cut --fields=1`; \
-		echo 'Depends: python3-pydbus'; \
+		echo 'Depends: python3-pydbus, python3-gi'; \
 		echo Version: $(DEBIAN_PV); \
 		echo Description: $(DEBIAN_DESCRIPTION); \
 	} > $(DEBIAN_DESTDIR)/DEBIAN/control


### PR DESCRIPTION
PyGObject is a direct dependency of linux-entra-sso, so we should declare it as a runtime dependency for our Debian package. Previously, we were fortunate that python3-pydbus already depends on python3-gi, which inadvertently fulfilled our dependency.