### PR TITLE
fix error handling for acquireTokenSilently and getAccounts

### DIFF
--- a/background.js
+++ b/background.js
@@ -188,6 +188,13 @@ async function load_accounts() {
         await waitFor(() => {
             return graph_api_token !== null;
         });
+        if ("error" in graph_api_token) {
+            ssoLog(
+                "couldn't aquire API token for avatar: " +
+                    graph_api_token.error,
+            );
+            return;
+        }
         ssoLog("API token acquired");
     }
     const response = await fetch(
@@ -337,7 +344,9 @@ async function on_message_native(response) {
         notify_state_change();
     } else if (response.command == "acquireTokenSilently") {
         if ("error" in response.message) {
-            ssoLog("could not acquire token silently: " + response.message.error);
+            graph_api_token = {
+                error: response.message.error,
+            };
             return;
         }
         graph_api_token = response.message.brokerTokenResponse;

--- a/background.js
+++ b/background.js
@@ -326,8 +326,8 @@ async function on_message_native(response) {
         prt_sso_cookie.hasData = true;
     } else if (response.command == "getAccounts") {
         accounts.queried = true;
-        if ("error" in response) {
-            ssoLog("could not get accounts: " + response.error);
+        if ("error" in response.message) {
+            ssoLog("could not get accounts: " + response.message.error);
             return;
         }
         accounts.registered = response.message.accounts;
@@ -336,8 +336,8 @@ async function on_message_native(response) {
             (host_versions.broker = response.message.linuxBrokerVersion);
         notify_state_change();
     } else if (response.command == "acquireTokenSilently") {
-        if ("error" in response) {
-            ssoLog("could not acquire token silently: " + response.error);
+        if ("error" in response.message) {
+            ssoLog("could not acquire token silently: " + response.message.error);
             return;
         }
         graph_api_token = response.message.brokerTokenResponse;

--- a/linux-entra-sso.py
+++ b/linux-entra-sso.py
@@ -198,7 +198,7 @@ class SsoMib:
 
 def run_as_native_messaging():
     iomutex = Lock()
-    no_broker = {"error": "Broker not available"}
+    processing_error = {"error": "Failure during request processing"}
 
     def respond(command, message):
         NativeMessaging.send_message(
@@ -253,7 +253,7 @@ def run_as_native_messaging():
             try:
                 handle_command(cmd, received_message)
             except Exception:  # pylint: disable=broad-except
-                respond(cmd, no_broker)
+                respond(cmd, processing_error)
 
 
 def run_interactive():


### PR DESCRIPTION
Fix error handling for acquireTokenSilently and getAccounts according to my understanding of linux-entra-sso.py. 

Note that I only tested the acquireTokenSilently path, but I don't see why getAccounts should behave differently.

Additionally, I fixed an indefinite wait in case avatar API token can't be acquired. 