### PR TITLE
ci: run build workflow on external pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ name: build browser extension
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to checkout the repository


### PR DESCRIPTION
Currently we don't run the build workflow on external pull requests. This makes it tricky to detect build and style issues on these requests.

As we already require explicit approval for all external contributors before running the action, it is fine to also enable the workflow. Further, I carefully checked the configuration of the repo with the poutine tool for possible bypasses.