### PR TITLE
ci: attest build only on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
 
       - name: attest extension artifacts
         uses: actions/attest-build-provenance@v1
+        if: github.event_name == 'push'
         with:
           subject-path: |
             build/Linux-Entra-SSO-v*


### PR DESCRIPTION
When running the build for external PRs, we do not have access to secrets (for good reason). By that, we also cannot perform the attestation step. Just skip it in these cases.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>