### PR TITLE
feat: indicate broker online state in UI

### DIFF
--- a/background.js
+++ b/background.js
@@ -418,6 +418,9 @@ function on_startup() {
         port_menu = port;
         port_menu.onMessage.addListener(on_message_menu);
         notify_state_change();
+        port_menu.onDisconnect.addListener(() => {
+            port_menu = null;
+        });
     });
 }
 

--- a/linux-entra-sso.py
+++ b/linux-entra-sso.py
@@ -198,7 +198,6 @@ class SsoMib:
 
 def run_as_native_messaging():
     iomutex = Lock()
-    processing_error = {"error": "Failure during request processing"}
 
     def respond(command, message):
         NativeMessaging.send_message(
@@ -252,8 +251,9 @@ def run_as_native_messaging():
             cmd = received_message["command"]
             try:
                 handle_command(cmd, received_message)
-            except Exception:  # pylint: disable=broad-except
-                respond(cmd, processing_error)
+            except Exception as exp:  # pylint: disable=broad-except
+                err = {"error": f"Failure during request processing: {str(exp)}"}
+                respond(cmd, err)
 
 
 def run_interactive():

--- a/popup/menu.css
+++ b/popup/menu.css
@@ -60,9 +60,12 @@ body.pending .entity {
     padding: 5px 5px 10px 5px;
     border-top: 1px solid #e0e0e0;
     font-size: 0.8em;
-    text-align: right;
     min-height: 1em;
     color: #707070;
+}
+
+.footer > div {
+    clear: both;
 }
 
 .footer a,
@@ -70,12 +73,6 @@ body.pending .entity {
     color: #707070;
 }
 
-.footer .left {
-    display: block;
-    float: left;
-}
-
 .footer .right {
-    display: block;
     float: right;
 }

--- a/popup/menu.html
+++ b/popup/menu.html
@@ -42,13 +42,19 @@ SPDX-FileCopyrightText: Copyright 2024 Siemens AG
             </div>
         </div>
         <div class="footer">
-            <a
-                href="https://github.com/siemens/linux-entra-sso"
-                target="_blank"
-                class="left"
-                >linux-entra-sso</a
-            >
-            <span id="version" class="right"></span>
+            <div id="broker-state">
+                <span id="broker-state-text" class="left">Identity broker</span>
+                <span id="broker-state-value" class="right">unknown</span>
+            </div>
+            <div>
+                <a
+                    href="https://github.com/siemens/linux-entra-sso"
+                    target="_blank"
+                    class="left"
+                    >linux-entra-sso</a
+                >
+                <span id="version" class="right"></span>
+            </div>
         </div>
         <script src="menu.js"></script>
     </body>

--- a/popup/menu.js
+++ b/popup/menu.js
@@ -44,7 +44,7 @@ bg_port.onMessage.addListener(async (m) => {
                 fallback.classList.remove("hidden");
             }
         }
-        if (m.enabled && m.broker_online) {
+        if (m.enabled) {
             document.getElementById("entity-me").classList.add("active");
             document.getElementById("entity-guest").classList.remove("active");
             active = true;
@@ -53,7 +53,13 @@ bg_port.onMessage.addListener(async (m) => {
             document.getElementById("entity-guest").classList.add("active");
             active = false;
         }
-        if (m.host_version && m.broker_version) {
+        let broker_state = m.broker_online
+            ? '<span style="color:green;">&#9210;</span> connected'
+            : '<span style="color:red;">&#9210;</span> disconnected';
+        document.getElementById("broker-state-value").innerHTML =
+            m.broker_version + " (" + broker_state + ")";
+
+        if (m.host_version) {
             let pvers = chrome.runtime.getManifest().version;
             let vstr = "v" + pvers;
             if (m.host_version !== pvers) {


### PR DESCRIPTION
In case the connection to the broker is lost, an indication of that situation should be given to the user. While this is not an error by itself (given that the broker is dbus-activated), it still provides valuable information for debugging. We now indicate this by adding a red circle around the avatar in this case, as well as stating the current status in the menu (when clicking on the icon).

Proposed-by: Jan Kiszka <jan.kiszka@siemens.com>