### PR TITLE
fix(firefox): include missing profile avatar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ ARCHIVE_NAME=$(PACKAGE_NAME)-$(RELEASE_TAG)
 COMMON_INPUT_FILES= \
 	LICENSES/MPL-2.0.txt \
 	background.js \
+	icons/profile-outline_48.png \
+	icons/profile-outline_48.png.license \
 	popup/menu.css \
 	popup/menu.js \
 	popup/menu.html
@@ -51,9 +53,7 @@ CHROME_INPUT_FILES= \
 	icons/linux-entra-sso_48.png \
 	icons/linux-entra-sso_48.png.license \
 	icons/linux-entra-sso_128.png \
-	icons/linux-entra-sso_128.png.license \
-	icons/profile-outline_48.png \
-	icons/profile-outline_48.png.license
+	icons/linux-entra-sso_128.png.license
 
 FIREFOX_INPUT_FILES= \
 	$(COMMON_INPUT_FILES) \
@@ -71,8 +71,6 @@ CHROME_PACKAGE_FILES= \
 	icons/linux-entra-sso_48.png.license \
 	icons/linux-entra-sso_128.png \
 	icons/linux-entra-sso_128.png.license \
-	icons/profile-outline_48.png \
-	icons/profile-outline_48.png.license \
 	popup/profile-outline.svg
 
 FIREFOX_PACKAGE_FILES= \

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ all package: clean $(CHROME_INPUT_FILES) $(FIREFOX_INPUT_FILES)
 		cp platform/$$P/manifest* build/$$P; \
 		cp -rf LICENSES background.js build/$$P/; \
 	done
-	cp icons/*.svg build/firefox/icons/
+	cp icons/*.svg icons/profile-outline_48.* build/firefox/icons/
 	cp icons/*.png* icons/profile-outline.svg build/chrome/icons/
 	cp popup/menu.* icons/linux-entra-sso.svg icons/profile-outline.svg build/firefox/popup/
 	cp popup/menu.* icons/linux-entra-sso.svg icons/profile-outline.svg build/chrome/popup/


### PR DESCRIPTION
In case the user does not have a profile picture, a fallback icon is used. This icon was not included in the firefox deployment, hence the loading of that failed and rejecting the promise (waiting for the icon to be come available).

Closes: #59