### PR TITLE
Fix internal issues in case of error during avatar loading

### DIFF
--- a/background.js
+++ b/background.js
@@ -251,7 +251,10 @@ async function load_accounts() {
     }
     accounts.active = accounts.registered[0];
     accounts.active.avatar = null;
-    accounts.active.avatar_imgdata = null;
+    accounts.active.avatar_imgdata = await load_icon(
+        "icons/profile-outline_48.png",
+        48,
+    );
     ssoLog("active account: " + accounts.active.username);
 
     // load profile picture and set it as icon
@@ -309,10 +312,6 @@ async function load_accounts() {
         accounts.active.avatar = dataUrl;
     } else {
         ssoLog("Warning: Could not get profile picture.");
-        accounts.active.avatar_imgdata = await load_icon(
-            "icons/profile-outline_48.png",
-            48,
-        );
     }
 }
 

--- a/background.js
+++ b/background.js
@@ -271,7 +271,7 @@ async function load_accounts() {
             return;
         } else if ("error" in graph_api_token) {
             ssoLog(
-                "couldn't aquire API token for avatar: " +
+                "couldn't acquire API token for avatar: " +
                     graph_api_token.error,
             );
             return;


### PR DESCRIPTION
In case an error happens between "login" (assignment of the account) and
loading the profile picture, we don't have any profile picture set. This
is problematic as downstream functions require a valid image data
object. To fix this, we load the dummy image upfront and then wait for
the actual image to be available.