### PR TITLE
feat: cache login state across browser restarts

### DIFF
--- a/background.js
+++ b/background.js
@@ -347,9 +347,6 @@ async function on_before_send_headers(e) {
     if (accept === undefined || !accept.value.includes("text/html")) {
         return { requestHeaders: e.requestHeaders };
     }
-    if (!is_operational()) {
-        return { requestHeaders: e.requestHeaders };
-    }
     let prt = await get_or_request_prt(e.url);
     if ("error" in prt) {
         return { requestHeaders: e.requestHeaders };

--- a/platform/chrome/manifest.json
+++ b/platform/chrome/manifest.json
@@ -23,7 +23,8 @@
     "permissions": [
         "alarms",
         "nativeMessaging",
-        "declarativeNetRequest"
+        "declarativeNetRequest",
+        "storage"
     ],
     "host_permissions": [
         "https://login.microsoftonline.com/*"

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -27,7 +27,8 @@
     "permissions": [
         "nativeMessaging",
         "webRequest",
-        "webRequestBlocking"
+        "webRequestBlocking",
+        "storage"
     ],
     "host_permissions": [
         "https://login.microsoftonline.com/*"


### PR DESCRIPTION
Recently we got reports about missing SSO in case the browser is
not already running when opening the Entra SSO page. This happens
because the login flow takes some time (in case of broker dbus
activation a couple of seconds) and only after it is completed we enable
the request filtering and try to acquire PRTs.

We now change this by caching the last logged-in user in the local
browser storage. By that, the extension can already request PRTs before
the login completed, as we already have the needed account information
to request the PRT. A nice side effect of that change is that we now
track the disabled / enabled state across browser restarts as well.

As this change requires the use of the local storage API, we also need
to grant permission in the manifests.