### PR TITLE
fix: set correct accept type when requesting avatar

### DIFF
--- a/background.js
+++ b/background.js
@@ -299,7 +299,7 @@ async function load_accounts() {
         "https://graph.microsoft.com/v1.0/me/photos/48x48/$value",
         {
             headers: {
-                "Content-Type": "image/jpeg",
+                Accept: "image/jpeg",
                 Authorization: "Bearer " + graph_api_token.accessToken,
             },
         },


### PR DESCRIPTION
When requesting the avatar picture, we set the Content-Type header instead of the Accept header. This is wrong, as the Content-Type header is (usually) a response header.

As the server anyways always responded with an image/jpeg type, this did not have any user visible effect. Anyways, we should clean this up, which we do here.