### PR TITLE
improvements of broker protocol and silent token refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ COMMON_INPUT_FILES= \
 	src/background.js \
 	src/broker.js \
 	src/platform-abstraction.js \
+	src/policy.js \
 	src/utils.js \
 	icons/profile-outline_48.png \
 	icons/profile-outline_48.png.license \
@@ -55,6 +56,8 @@ CHROME_INPUT_FILES= \
 	platform/chrome/manifest.json \
 	platform/chrome/manifest.json.license \
 	platform/chrome/js/platform.js \
+	platform/chrome/storage-schema.json \
+	platform/chrome/storage-schema.json.license \
 	icons/linux-entra-sso_48.png \
 	icons/linux-entra-sso_48.png.license \
 	icons/linux-entra-sso_128.png \
@@ -82,6 +85,8 @@ CHROME_PACKAGE_FILES= \
 	src/platform.js \
 	manifest.json \
 	manifest.json.license \
+	storage-schema.json \
+	storage-schema.json.license \
 	icons/linux-entra-sso_48.png \
 	icons/linux-entra-sso_48.png.license \
 	icons/linux-entra-sso_128.png \
@@ -123,6 +128,7 @@ all package: clean $(CHROME_INPUT_FILES) $(FIREFOX_INPUT_FILES) $(THUNDERBIRD_IN
 		cp platform/$$P/js/* build/$$P/src; \
 	done
 	cp -r build/firefox/icons build/firefox/popup build/thunderbird/
+	cp platform/chrome/storage* build/chrome/
 	cp icons/*.svg icons/profile-outline_48.* build/firefox/icons/
 	cp icons/*.png* icons/profile-outline.svg build/chrome/icons/
 	cp popup/menu.* icons/linux-entra-sso.svg icons/profile-outline.svg build/firefox/popup/

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -32,5 +32,20 @@ URL. On Chrome and Chromium, the `PRT SSO Cookie` is requested periodically
 with a generic URL. The returned token is injected into all http requests
 hitting the Entra ID login URL.
 
+### Note on required and optional host permissions
+
+We use the `WebRequest` (Firefox) or `declarativeNetRequest` (Chrome) API to
+inject the `PRT SSO Cookie` into requests targeting the login provider. To support
+this, we need the permission to access your data on `https://login.microsoftonline.com/`.
+This permission is (usually) requested at extension install time (required permission).
+
+For single-page applications (SPAs, like the Teams PWA) that perform automated token
+refreshes in the background, we further need the permission to access your data on
+the corresponding domains. To minimize the number of permissions we request, we provide users
+with the ability to grant these permissions on a case-by-case basis via the extension's UI or policy settings.
+Granted permissions can also be revoked through the same interface.
+
+## Privacy statement for Microsoft services
+
 The privacy statement for all Microsoft provided services is found on
 <https://privacy.microsoft.com/en-us/PrivacyStatement>.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The extension requires [PyGObject](https://pygobject.gnome.org/) and [pydbus](ht
 - On Arch Linux: `sudo pacman -S python-gobject python-pydbus`
 - If you are using a Python version manager such as `asdf` you must install the Python packages manually: `pip install PyGObject pydbus`
 
+**Note:** System-wide installation and configuration is supported. For more information, see [Global Install](docs/global_install.md).
+
 ### Firefox & Thunderbird: Signed Version from GitHub Releases
 
 You can download a **signed version** of the browser extension directly from our [GitHub Releases](https://github.com/siemens/linux-entra-sso/releases).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Get the `linux_entra_sso-<version>.xpi` file from the [project's releases page](
 
 After installing the extension, enable the following permission:
 
-Access your data for `https://login.microsoftonline.com`
+Access your data for `https://login.microsoftonline.com`.
+To support transparent re-login on applications using this identity provider, you need to grant permission for these domains as well.
+For details, see [PRIVACY.md](PRIVACY.md).
 
 ### Chrome & Brave: Signed Extension from Chrome Web Store
 
@@ -118,6 +120,22 @@ For details, have a look at the Makefile.
 **No configuration is required.** The SSO is automatically enabled.
 If you want to disable the SSO for this session, click on the tray icon and select the guest account.
 In case you are already logged in, you might need to clear all cookies on `login.microsoftonline.com`.
+
+### Single Page Applications
+
+For single-page applications (SPAs, like the Teams PWA) that perform automated re-logins in the background,
+ensure the extension has the necessary permissions to interact with the SPA's domain.
+Otherwise, a manual re-login after approximately 24 hours (depending on the tenant's configuration) may be required.
+
+To grant the necessary permissions, follow these steps:
+
+1. Open the SPA URL in your web browser
+2. Click on the extension's tray icon
+3. Click on "Background SSO (enable)"
+4. A dot should appear next to the domain indicating that permission has been granted
+
+Once configured, no further authentication requests will be needed.
+To revoke permissions, return to the extension's settings and select the domain again.
 
 ### Technical Background
 

--- a/docs/global_install.md
+++ b/docs/global_install.md
@@ -1,0 +1,105 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2025 Siemens AG
+SPDX-License-Identifier: MPL-2.0
+-->
+# System-Wide Install via Policy
+
+We support both system-wide installation and managed configuration.
+
+## Installation
+
+A system-wide install is supported for both Firefox and Chromium-based browsers.
+The paths of the policy files may vary across browsers and distributions.
+On Debian, the following paths are known to work.
+
+### Firefox
+
+Example: `/etc/firefox/policies/policies.json`
+
+```json
+{
+  "policies": {
+    "ExtensionSettings": {
+      "linux-entra-sso@example.com": {
+        "installation_mode": "force_installed",
+        "install_url": "file:///path/to/extension.xpi"
+      }
+    }
+  }
+}
+```
+
+### Chromium
+
+Example: `/etc/chromium/policies/managed/policies.json`
+
+```json
+{
+  "ExtensionSettings": {
+    "jlnfnnolkbjieggibinobhkjdfbpcohn": {
+      "runtime_allowed_hosts": ["https://login.microsoftonline.com"],
+      "installation_mode": "force_installed",
+      "update_url": "file:///path/to/chrome-update.xml"
+    }
+  }
+}
+```
+
+Chrome Update (`chrome-update.xml`) file:
+
+```xml
+<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+  <app appid='jlnfnnolkbjieggibinobhkjdfbpcohn'>
+    <updatecheck codebase='file:///path/to/extension.crx' version=pinned-version' />
+  </app>
+</gupdate>
+```
+
+## Configuration
+
+We implement the `storage.managed` webextension API to allow injection of configuration.
+By that, a system administrator can configure settings of the extension via the policy files.
+
+> [!NOTE]
+> Some settings cannot be automatically enabled (e.g., granting permissions), as they require
+> user interaction. In this case, the extension detects a configuration update and notifies
+> the user via the tray icon. The user can then apply the changes by clicking a link in the
+> tray menu.
+
+### Managed settings
+
+The settings are added to the policy file under `3rdparty.extensions.<id>`. Example:
+
+
+```json
+{
+  "3rdparty": {
+    "extensions": {
+      "linux-entra-sso@example.com": {
+        "wellKnownApps": {
+          "example.com": true,
+        }
+      }
+    }
+  }
+}
+```
+
+#### `wellKnownApps`
+
+To allow background SSO, the extension needs the `host_permissions` for both the application
+domain, as well as for the login provider. Hereby, the app domain can be anything, but is
+usually known to the company managing the devices.
+
+Value: Dictionary of key-value pairs (string, bool), where the key is the domain and the
+value denotes if SSO is enabled. The domain must precisely match. Wildcards are not (yet)
+supported.
+
+```json
+{
+  "wellKnownApps": {
+    "example.com": true,
+    "another.example.com": false
+  }
+}
+```

--- a/platform/chrome/js/platform.js
+++ b/platform/chrome/js/platform.js
@@ -10,7 +10,6 @@ export class PlatformChrome extends Platform {
     browser = "Chrome";
     #update_net_rules_cb = null;
 
-    static SSO_URL = "https://login.microsoftonline.com";
     static CHROME_PRT_SSO_REFRESH_INTERVAL_MIN = 30;
 
     constructor() {
@@ -59,7 +58,7 @@ export class PlatformChrome extends Platform {
         ssoLog("update network rules");
         let prt = await this.broker.acquirePrtSsoCookie(
             this.account,
-            PlatformChrome.SSO_URL,
+            Platform.SSO_URL,
         );
         if ("error" in prt) {
             ssoLogError("could not acquire PRT SSO cookie: " + prt.error);
@@ -70,8 +69,8 @@ export class PlatformChrome extends Platform {
                 id: 1,
                 priority: 1,
                 condition: {
-                    urlFilter: PlatformChrome.SSO_URL + "/*",
-                    resourceTypes: ["main_frame"],
+                    urlFilter: Platform.SSO_URL + "/*",
+                    resourceTypes: ["main_frame", "sub_frame"],
                 },
                 action: {
                     type: "modifyHeaders",

--- a/platform/chrome/manifest.json
+++ b/platform/chrome/manifest.json
@@ -24,9 +24,13 @@
         "alarms",
         "nativeMessaging",
         "declarativeNetRequest",
-        "storage"
+        "storage",
+        "activeTab"
     ],
     "host_permissions": [
         "https://login.microsoftonline.com/*"
+    ],
+    "optional_host_permissions": [
+        "https://*/*"
     ]
 }

--- a/platform/chrome/manifest.json
+++ b/platform/chrome/manifest.json
@@ -32,5 +32,8 @@
     ],
     "optional_host_permissions": [
         "https://*/*"
-    ]
+    ],
+    "storage": {
+        "managed_schema": "storage-schema.json"
+    }
 }

--- a/platform/chrome/storage-schema.json
+++ b/platform/chrome/storage-schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "wellKnownApps": {
+      "description": "Apps that are allowed to perform background SSO.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/platform/chrome/storage-schema.json.license
+++ b/platform/chrome/storage-schema.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: Copyright 2025 Siemens AG
+
+SPDX-License-Identifier: MPL-2.0

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -9,7 +9,7 @@
     "browser_specific_settings": {
         "gecko": {
             "id": "linux-entra-sso@example.com",
-            "strict_min_version": "112.0",
+            "strict_min_version": "128.0",
             "update_url": "https://siemens.github.io/linux-entra-sso/firefox/updates.json"
         }
     },
@@ -27,9 +27,13 @@
         "nativeMessaging",
         "webRequest",
         "webRequestBlocking",
-        "storage"
+        "storage",
+        "activeTab"
     ],
     "host_permissions": [
         "https://login.microsoftonline.com/*"
+    ],
+    "optional_host_permissions": [
+        "https://*/*"
     ]
 }

--- a/platform/thunderbird/manifest.json
+++ b/platform/thunderbird/manifest.json
@@ -9,7 +9,7 @@
     "browser_specific_settings": {
         "gecko": {
             "id": "linux-entra-sso@example.com",
-            "strict_min_version": "112.0",
+            "strict_min_version": "128.0",
             "update_url": "https://siemens.github.io/linux-entra-sso/thunderbird/updates.json"
         }
     },

--- a/popup/menu.css
+++ b/popup/menu.css
@@ -98,6 +98,10 @@ body.pending .entity {
     color: red;
 }
 
+.warning-text {
+    color: rgb(255, 120, 0);
+}
+
 span.link {
     text-decoration: underline dotted;
     cursor: pointer;
@@ -107,5 +111,9 @@ span.link {
     display: none;
 }
 .disconnected #withdraw-access {
+    display: none;
+}
+
+#bg-sso-state.immutable .link {
     display: none;
 }

--- a/popup/menu.css
+++ b/popup/menu.css
@@ -5,7 +5,7 @@
 
 html,
 body {
-    width: 320px;
+    width: 420px;
     padding: 0;
     margin: 0;
 }
@@ -52,10 +52,10 @@ body.pending .entity {
     height: 48px;
 }
 
-#broker-state.connected .state-connected-icon {
+.connected .state-connected-icon {
     color: green;
 }
-#broker-state.disconnected .state-connected-icon {
+.disconnected .state-connected-icon {
     color: red;
 }
 
@@ -64,14 +64,20 @@ body.pending .entity {
 }
 
 .footer {
-    padding: 5px 5px 10px 5px;
-    border-top: 1px solid #e0e0e0;
+    padding-bottom: 5px;
     font-size: 0.8em;
     min-height: 1em;
     color: #707070;
 }
 
-.footer > div {
+.footer > .footer-block {
+    border-top: 1px solid #e0e0e0;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    margin: 0px 5px 0px 5px;
+}
+
+.footer > .footer-block > div {
     clear: both;
 }
 
@@ -82,4 +88,24 @@ body.pending .entity {
 
 .footer .right {
     float: right;
+}
+
+.footer .clear {
+    clear: both;
+}
+
+.error-text {
+    color: red;
+}
+
+span.link {
+    text-decoration: underline dotted;
+    cursor: pointer;
+}
+
+.connected #grant-access {
+    display: none;
+}
+.disconnected #withdraw-access {
+    display: none;
 }

--- a/popup/menu.html
+++ b/popup/menu.html
@@ -46,6 +46,12 @@ SPDX-FileCopyrightText: Copyright 2024 Siemens AG
                 <span id="message-text" class="error-text"></span>
                 <span id="grant-access-sso" class="link">(enable)</span>
             </div>
+            <div id="gpo-update-box" class="footer-block hidden">
+                <span id="gpo-update-text" class="warning-text"
+                    >A managed policy update is pending</span
+                >
+                <span id="apply-gpo-update" class="link">(apply)</span>
+            </div>
             <div class="footer-block">
                 <div class="disconnected" id="bg-sso-state">
                     <span>Background SSO</span>

--- a/popup/menu.html
+++ b/popup/menu.html
@@ -42,23 +42,40 @@ SPDX-FileCopyrightText: Copyright 2024 Siemens AG
             </div>
         </div>
         <div class="footer">
-            <div id="broker-state">
-                <span id="broker-state-text" class="left">Identity broker</span>
-                <span class="right">
-                    <span id="broker-version"></span>
-                    &#40;
-                    <span class="state-connected-icon">&#9210;</span>
-                    <span id="broker-state-value">unknown</span>&#41;
-                </span>
+            <div id="message-box" class="footer-block hidden">
+                <span id="message-text" class="error-text"></span>
+                <span id="grant-access-sso" class="link">(enable)</span>
             </div>
-            <div>
-                <a
-                    href="https://github.com/siemens/linux-entra-sso"
-                    target="_blank"
-                    class="left"
-                    >linux-entra-sso</a
-                >
-                <span id="version" class="right"></span>
+            <div class="footer-block">
+                <div class="disconnected" id="bg-sso-state">
+                    <span>Background SSO</span>
+                    <span id="grant-access" class="link">(enable)</span>
+                    <span id="withdraw-access" class="link">(disable)</span>
+                    <span class="right">
+                        <span class="state-connected-icon">&#9210;</span>
+                        <span id="current-url"></span>
+                    </span>
+                </div>
+                <div id="broker-state">
+                    <span id="broker-state-text" class="left"
+                        >Identity broker</span
+                    >
+                    <span class="right">
+                        <span id="broker-version"></span>
+                        &#40;
+                        <span class="state-connected-icon">&#9210;</span>
+                        <span id="broker-state-value">unknown</span>&#41;
+                    </span>
+                </div>
+                <div>
+                    <a
+                        href="https://github.com/siemens/linux-entra-sso"
+                        target="_blank"
+                        class="left"
+                        >linux-entra-sso</a
+                    >
+                    <span id="version" class="right"></span>
+                </div>
             </div>
         </div>
         <script src="menu.js"></script>

--- a/popup/menu.js
+++ b/popup/menu.js
@@ -8,6 +8,10 @@ let bg_port = chrome.runtime.connect({ name: "linux-entra-sso" });
 let inflight = false;
 /* user is logged in */
 let active = false;
+/* sso provider url */
+let sso_url = null;
+/* current URL filter */
+let current_filter = null;
 
 function set_inflight() {
     if (inflight) return false;
@@ -24,6 +28,7 @@ function clear_inflight() {
 bg_port.onMessage.addListener(async (m) => {
     if (m.event == "stateChanged") {
         clear_inflight();
+        check_bg_sso_enabled();
         if (m.account !== null) {
             document.getElementById("me-name").innerText = m.account.name;
             document.getElementById("me-email").innerText = m.account.username;
@@ -75,6 +80,8 @@ bg_port.onMessage.addListener(async (m) => {
             }
             document.getElementById("version").innerText = vstr;
         }
+        sso_url = m.sso_url;
+        check_sso_provider_perms();
     }
 });
 
@@ -88,3 +95,85 @@ document.getElementById("entity-guest").addEventListener("click", (event) => {
     if (!set_inflight(this)) return;
     bg_port.postMessage({ command: "disable" });
 });
+
+function check_sso_provider_perms() {
+    msgbox = document.getElementById("message-box");
+    msgtext = document.getElementById("message-text");
+    grant_access_text = document.getElementById("grant-access-sso");
+    const permissionsToCheck = {
+        origins: [sso_url + "/*"],
+    };
+    chrome.permissions.contains(permissionsToCheck).then((result) => {
+        if (result) {
+            msgbox.classList.add("hidden");
+            msgbox.innerText = "";
+        } else {
+            msgtext.innerText = "No permission to access login provider.";
+            msgbox.classList.remove("hidden");
+        }
+    });
+}
+
+async function check_bg_sso_enabled() {
+    bg_sso_classes = document.getElementById("bg-sso-state").classList;
+    let [tab] = await chrome.tabs.query({ currentWindow: true, active: true });
+    if (!Object.hasOwn(tab, "url") || !tab.url.startsWith("https://")) {
+        bg_sso_classes.add("hidden");
+        return;
+    }
+    bg_sso_classes.remove("hidden");
+    var tab_hostname = new URL(tab.url).hostname;
+    current_filter = "https://" + tab_hostname + "/*";
+    document.getElementById("current-url").innerText = tab_hostname;
+    const permissionsToCheck = {
+        origins: [current_filter],
+    };
+    chrome.permissions.contains(permissionsToCheck).then((result) => {
+        var sso_state_classes =
+            document.getElementById("bg-sso-state").classList;
+        if (result) {
+            sso_state_classes.replace("disconnected", "connected");
+        } else {
+            sso_state_classes.replace("connected", "disconnected");
+        }
+    });
+}
+
+function request_host_permission(urls) {
+    if (urls === null || urls.length == 0) return;
+    const permissionsToRequest = {
+        origins: urls,
+    };
+    chrome.permissions.request(permissionsToRequest).then((granted) => {
+        if (granted) {
+            console.log("Permission granted");
+            // No need to update the UI as this will trigger the permission
+            // changed event in the background script, which triggers an
+            // UI update.
+        } else {
+            console.log("Failed to get permission");
+        }
+    });
+    // The permission-request window might open below the webextensions panel.
+    // This has been observed on Thunderbird 128. Close the panel, so the user
+    // can grant the permission.
+    window.close();
+}
+
+// Requires user interaction, as otherwise we lack the permission to
+// request further host permissions
+document.getElementById("grant-access").addEventListener("click", (event) => {
+    request_host_permission([current_filter]);
+});
+
+document
+    .getElementById("withdraw-access")
+    .addEventListener("click", (event) => {
+        remove_host_permission([current_filter]);
+    });
+
+document
+    .getElementById("grant-access-sso")
+    .addEventListener("click", (event) => {
+        request_host_permission([sso_url + "/*"]);
+    });

--- a/src/account.js
+++ b/src/account.js
@@ -3,10 +3,13 @@
  * SPDX-FileCopyrightText: Copyright 2025 Siemens
  */
 
+import { ssoLog, load_icon } from "./utils.js";
+import { Deferred } from "./utils.js";
+
 export class Account {
     #broker_obj = null;
+    #avatar_imgdata = null;
     avatar = null;
-    avatar_imgdata = null;
 
     constructor(broker_obj) {
         this.#broker_obj = { ...broker_obj };
@@ -30,5 +33,203 @@ export class Account {
             username: this.username(),
             avatar: this.avatar,
         };
+    }
+
+    async getAvatarImgData() {
+        if (!this.#avatar_imgdata) {
+            this.#avatar_imgdata = await load_icon(
+                "/icons/profile-outline_48.png",
+                48,
+            );
+        }
+        return this.#avatar_imgdata;
+    }
+
+    setAvatarImgData(data) {
+        this.#avatar_imgdata = data;
+    }
+
+    async getDecoratedAvatar(color, width) {
+        let imgdata = await this.getAvatarImgData();
+        const sWidth = imgdata.width;
+        const lineWidth = Math.min(2, width / 12);
+        let buffer = new OffscreenCanvas(sWidth, sWidth);
+        let ctx_buffer = buffer.getContext("2d");
+        ctx_buffer.putImageData(imgdata, 0, 0);
+
+        let canvas = new OffscreenCanvas(width, width);
+        let ctx = canvas.getContext("2d");
+        ctx.save();
+        const img_margin = color === null ? 0 : lineWidth + 1;
+        ctx.beginPath();
+        ctx.arc(
+            width / 2,
+            width / 2,
+            width / 2 - img_margin,
+            0,
+            Math.PI * 2,
+            false,
+        );
+        ctx.clip();
+        ctx.drawImage(
+            buffer,
+            0,
+            0,
+            sWidth,
+            sWidth,
+            img_margin,
+            img_margin,
+            width - img_margin * 2,
+            width - img_margin * 2,
+        );
+        ctx.restore();
+        if (color === null) {
+            return ctx.getImageData(0, 0, width, width);
+        }
+        ctx.strokeStyle = color;
+        ctx.lineWidth = lineWidth;
+        ctx.beginPath();
+        ctx.arc(
+            width / 2,
+            width / 2,
+            width / 2 - Math.min(1, lineWidth / 2),
+            0,
+            Math.PI * 2,
+            false,
+        );
+        ctx.stroke();
+        return ctx.getImageData(0, 0, width, width);
+    }
+}
+
+export class AccountManager {
+    #broker = null;
+    #graph_token = null;
+    #registered = [];
+    #active = null;
+    #queried = false;
+
+    constructor(broker) {
+        this.#broker = broker;
+    }
+
+    hasAccounts() {
+        return this.#registered.length != 0;
+    }
+
+    /**
+     * @returns if we got account data from the broker
+     */
+    hasBrokerData() {
+        return this.#queried;
+    }
+
+    getActive() {
+        return this.#active;
+    }
+
+    getRegistered() {
+        return this.#registered;
+    }
+
+    async loadAccounts() {
+        if (this.hasBrokerData()) return;
+
+        ssoLog("loading accounts");
+        const _accounts = await this.#broker.getAccounts();
+        if (!_accounts) return;
+        this.#registered = _accounts;
+        this.#active = _accounts[0];
+        ssoLog("active account: " + this.#active.username());
+
+        // load profile picture and set it as icon
+        if (
+            !this.#graph_token ||
+            this.#graph_token.expiresOn < Date.now() + 60000
+        ) {
+            this.#graph_token = await this.#broker.acquireTokenSilently(
+                this.#active,
+            );
+            if ("error" in this.#graph_token) {
+                ssoLog("couldn't acquire API token for avatar:");
+                console.log(this.#graph_token.error);
+                return;
+            }
+            ssoLog("API token acquired");
+        }
+        const response = await fetch(
+            "https://graph.microsoft.com/v1.0/me/photos/48x48/$value",
+            {
+                headers: {
+                    Accept: "image/jpeg",
+                    Authorization: "Bearer " + this.#graph_token.accessToken,
+                },
+            },
+        );
+        if (response.ok) {
+            let avatar = await createImageBitmap(await response.blob());
+            let canvas = new OffscreenCanvas(48, 48);
+            let ctx = canvas.getContext("2d");
+            ctx.save();
+            ctx.beginPath();
+            ctx.arc(24, 24, 24, 0, Math.PI * 2, false);
+            ctx.clip();
+            ctx.drawImage(avatar, 0, 0);
+            ctx.restore();
+            /* serialize image to data URL (ugly, but portable) */
+            let blob = await canvas.convertToBlob();
+            const dataUrl = await new Promise((r) => {
+                let a = new FileReader();
+                a.onload = r;
+                a.readAsDataURL(blob);
+            }).then((e) => e.target.result);
+
+            /* store image data */
+            ctx.clearRect(0, 0, 48, 48);
+            ctx.drawImage(avatar, 0, 0, 48, 48);
+            this.#active.setAvatarImgData(ctx.getImageData(0, 0, 48, 48));
+            this.#active.avatar = dataUrl;
+        } else {
+            ssoLog("Warning: Could not get profile picture.");
+        }
+    }
+
+    /*
+     * Store the current state in the local storage.
+     * To not leak account data in disabled state, we clear the account object.
+     */
+    async persist(sso_state) {
+        let ssostate = {
+            state: sso_state,
+            account:
+                sso_state && this.#active !== null
+                    ? this.#active.brokerObject()
+                    : null,
+        };
+        return chrome.storage.local.set({ ssostate });
+    }
+
+    async restore() {
+        let dfd = new Deferred();
+        chrome.storage.local.get("ssostate", (data) => {
+            let state_active = true;
+            if (data.ssostate) {
+                state_active = data.ssostate.state;
+                if (
+                    state_active &&
+                    data.ssostate.account &&
+                    !this.hasAccounts()
+                ) {
+                    this.#registered = [new Account(data.ssostate.account)];
+                    this.#active = this.#registered[0];
+                    ssoLog(
+                        "temporarily using last-known account: " +
+                            this.#active.username(),
+                    );
+                }
+            }
+            dfd.resolve(state_active);
+        });
+        return dfd.promise;
     }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -87,7 +87,8 @@ function notify_state_change(ui_only = false) {
     const gpo_update = policyManager.getPolicyUpdate(
         PLATFORM.well_known_app_filters,
     );
-    update_tray(gpo_update.pending);
+    let action_needed = !PLATFORM.sso_url_permitted || gpo_update.pending;
+    update_tray(action_needed);
     if (!ui_only && broker.isConnected()) {
         ssoLog("update handlers");
         PLATFORM.update_request_handlers(

--- a/src/background.js
+++ b/src/background.js
@@ -33,6 +33,22 @@ function is_operational() {
 }
 
 /*
+ * Read the host_permissions from the manifest.
+ * We import them lazy, as they only get relevant on token_refresh.
+ */
+async function load_host_permissions() {
+    await chrome.permissions
+        .getAll()
+        .then((p) => (PLATFORM.well_known_app_filters = p.origins));
+}
+
+async function on_permissions_changed() {
+    ssoLog("permissions changed, reload host_permissions");
+    await load_host_permissions();
+    notify_state_change();
+}
+
+/*
  * Update the UI according to the current state
  */
 function update_ui() {
@@ -120,6 +136,7 @@ function notify_state_change(ui_only = false) {
         enabled: state_active,
         host_version: host_versions.native,
         broker_version: host_versions.broker,
+        sso_url: PLATFORM.getSsoUrl(),
     });
 }
 
@@ -287,6 +304,9 @@ function on_startup() {
     }
     initialized = true;
     ssoLog("start linux-entra-sso on " + PLATFORM.browser);
+    load_host_permissions();
+    chrome.permissions.onAdded.addListener(on_permissions_changed);
+    chrome.permissions.onRemoved.addListener(on_permissions_changed);
 
     broker = new Broker("linux_entra_sso", on_broker_state_change);
     notify_state_change(true);

--- a/src/background.js
+++ b/src/background.js
@@ -5,25 +5,20 @@
 
 import { create_platform } from "./platform.js";
 import { Broker } from "./broker.js";
-import { Account } from "./account.js";
+import { AccountManager } from "./account.js";
 import { ssoLog } from "./utils.js";
 import { PolicyManager } from "./policy.js";
 
 const PLATFORM = create_platform();
 let broker = null;
 let policyManager = null;
+let accountManager = null;
 
-let accounts = {
-    registered: [],
-    active: null,
-    queried: false,
-};
 let host_versions = {
     native: null,
     broker: null,
 };
 let initialized = false;
-let graph_api_token = null;
 let state_active = true;
 let port_menu = null;
 
@@ -31,7 +26,7 @@ let port_menu = null;
  * Check if all conditions for SSO are met
  */
 function is_operational() {
-    return state_active && accounts.active;
+    return state_active && accountManager.getActive() !== null;
 }
 
 async function on_permissions_changed() {
@@ -43,11 +38,12 @@ async function on_permissions_changed() {
 /*
  * Update the UI according to the current state
  */
-function update_tray(action_needed) {
+async function update_tray(action_needed) {
     chrome.action.enable();
     if (is_operational()) {
+        let account = accountManager.getActive();
         let imgdata = {};
-        let icon_title = accounts.active.username();
+        let icon_title = account.username();
 
         // shorten the title a bit
         if (PLATFORM.browser == "Thunderbird")
@@ -57,17 +53,11 @@ function update_tray(action_needed) {
         chrome.action.setTitle({
             title: icon_title,
         });
-        // we do not yet have the avatar image
-        if (!accounts.active.avatar_imgdata) return;
         if (!broker.isRunning()) {
             color = "#cc0000";
         }
         for (const r of [16, 32, 48]) {
-            imgdata[r] = decorate_avatar(
-                accounts.active.avatar_imgdata,
-                color,
-                r,
-            );
+            imgdata[r] = await account.getDecoratedAvatar(color, r);
         }
         chrome.action.setIcon({
             imageData: imgdata,
@@ -81,7 +71,7 @@ function update_tray(action_needed) {
     PLATFORM.setIconDisabled();
     let title = "EntraID SSO disabled. Click to enable.";
     if (state_active) title = "EntraID SSO disabled (waiting for broker).";
-    if (accounts.registered.length == 0) {
+    if (accountManager.hasAccounts() == 0) {
         title = "EntraID SSO disabled (no accounts registered).";
         if (!broker.isRunning()) chrome.action.disable();
     }
@@ -94,19 +84,6 @@ function update_tray(action_needed) {
 }
 
 /*
- * Store the current state in the local storage.
- * To not leak account data in disabled state, we clear the account object.
- */
-function update_storage() {
-    let default_account = accounts.registered[0];
-    let ssostate = {
-        state: state_active,
-        account: state_active ? default_account.brokerObject() : null,
-    };
-    chrome.storage.local.set({ ssostate });
-}
-
-/*
  * Update the tray icon, (un)register the handlers and notify
  * the menu about a state change.
  */
@@ -115,21 +92,20 @@ function notify_state_change(ui_only = false) {
         PLATFORM.well_known_app_filters,
     );
     update_tray(gpo_update.pending);
-    if (!ui_only) {
+    if (!ui_only && broker.isConnected()) {
         ssoLog("update handlers");
         PLATFORM.update_request_handlers(
-            is_operational(),
-            accounts.active,
+            state_active,
+            accountManager.getActive(),
             broker,
         );
     }
     if (port_menu === null) return;
     port_menu.postMessage({
         event: "stateChanged",
-        account:
-            accounts.registered.length > 0
-                ? accounts.registered[0].toMenuObject()
-                : null,
+        account: accountManager.hasAccounts()
+            ? accountManager.getRegistered()[0].toMenuObject()
+            : null,
         broker_online: broker.isRunning(),
         enabled: state_active,
         host_version: host_versions.native,
@@ -139,143 +115,13 @@ function notify_state_change(ui_only = false) {
     });
 }
 
-function decorate_avatar(imgdata, color, width) {
-    const sWidth = imgdata.width;
-    const lineWidth = Math.min(2, width / 12);
-    let buffer = new OffscreenCanvas(sWidth, sWidth);
-    let ctx_buffer = buffer.getContext("2d");
-    ctx_buffer.putImageData(imgdata, 0, 0);
-
-    let canvas = new OffscreenCanvas(width, width);
-    let ctx = canvas.getContext("2d");
-    ctx.save();
-    const img_margin = color === null ? 0 : lineWidth + 1;
-    ctx.beginPath();
-    ctx.arc(
-        width / 2,
-        width / 2,
-        width / 2 - img_margin,
-        0,
-        Math.PI * 2,
-        false,
-    );
-    ctx.clip();
-    ctx.drawImage(
-        buffer,
-        0,
-        0,
-        sWidth,
-        sWidth,
-        img_margin,
-        img_margin,
-        width - img_margin * 2,
-        width - img_margin * 2,
-    );
-    ctx.restore();
-    if (color === null) {
-        return ctx.getImageData(0, 0, width, width);
-    }
-    ctx.strokeStyle = color;
-    ctx.lineWidth = lineWidth;
-    ctx.beginPath();
-    ctx.arc(
-        width / 2,
-        width / 2,
-        width / 2 - Math.min(1, lineWidth / 2),
-        0,
-        Math.PI * 2,
-        false,
-    );
-    ctx.stroke();
-    return ctx.getImageData(0, 0, width, width);
-}
-
-async function load_icon(path, width) {
-    const response = await fetch(chrome.runtime.getURL(path));
-    let imgBitmap = await createImageBitmap(await response.blob(), {
-        resizeWidth: width,
-        resizeHeight: width,
-    });
-    let canvas = new OffscreenCanvas(width, width);
-    let ctx = canvas.getContext("2d");
-    ctx.save();
-    ctx.drawImage(imgBitmap, 0, 0);
-    ctx.restore();
-    return ctx.getImageData(0, 0, width, width);
-}
-
-async function load_accounts() {
-    ssoLog("loading accounts");
-    if (accounts.queried) return;
-
-    const _accounts = await broker.getAccounts();
-    if (!_accounts) return;
-    accounts.queried = true;
-    accounts.registered = _accounts;
-    accounts.active = _accounts[0];
-    accounts.active.avatar = null;
-    accounts.active.avatar_imgdata = await load_icon(
-        "/icons/profile-outline_48.png",
-        48,
-    );
-    ssoLog("active account: " + accounts.active.username());
-
-    // load profile picture and set it as icon
-    if (!graph_api_token || graph_api_token.expiresOn < Date.now() + 60000) {
-        graph_api_token = null;
-        graph_api_token = await broker.acquireTokenSilently(accounts.active);
-        if ("error" in graph_api_token) {
-            ssoLog("couldn't acquire API token for avatar:");
-            console.log(graph_api_token.error);
-            return;
-        }
-        ssoLog("API token acquired");
-    }
-    const response = await fetch(
-        "https://graph.microsoft.com/v1.0/me/photos/48x48/$value",
-        {
-            headers: {
-                Accept: "image/jpeg",
-                Authorization: "Bearer " + graph_api_token.accessToken,
-            },
-        },
-    );
-    if (response.ok) {
-        let avatar = await createImageBitmap(await response.blob());
-        let canvas = new OffscreenCanvas(48, 48);
-        let ctx = canvas.getContext("2d");
-        ctx.save();
-        ctx.beginPath();
-        ctx.arc(24, 24, 24, 0, Math.PI * 2, false);
-        ctx.clip();
-        ctx.drawImage(avatar, 0, 0);
-        ctx.restore();
-        /* serialize image to data URL (ugly, but portable) */
-        let blob = await canvas.convertToBlob();
-        const dataUrl = await new Promise((r) => {
-            let a = new FileReader();
-            a.onload = r;
-            a.readAsDataURL(blob);
-        }).then((e) => e.target.result);
-
-        /* store image data */
-        ctx.clearRect(0, 0, 48, 48);
-        ctx.drawImage(avatar, 0, 0, 48, 48);
-        accounts.active.avatar_imgdata = ctx.getImageData(0, 0, 48, 48);
-        accounts.active.avatar = dataUrl;
-    } else {
-        ssoLog("Warning: Could not get profile picture.");
-    }
-    update_storage();
-}
-
 async function on_message_menu(request) {
     if (request.command == "enable") {
         state_active = true;
     } else if (request.command == "disable") {
         state_active = false;
     }
-    update_storage();
+    accountManager.persist(state_active);
     notify_state_change();
 }
 
@@ -283,8 +129,9 @@ async function on_broker_state_change(online) {
     if (online) {
         ssoLog("connection to broker restored");
         // only reload data if we did not see the broker before
-        if (accounts.queried === false) {
-            await load_accounts();
+        if (!accountManager.hasBrokerData()) {
+            await accountManager.loadAccounts();
+            accountManager.persist(state_active);
             notify_state_change();
         }
         if (host_versions.native === null) {
@@ -311,41 +158,30 @@ function on_startup() {
     ssoLog("start linux-entra-sso on " + PLATFORM.browser);
     policyManager = new PolicyManager();
 
-    Promise.all([
-        PLATFORM.update_host_permissions(),
-        policyManager.load_policies(),
-    ]).then(() => {
-        notify_state_change(true);
-    });
-
     chrome.storage.onChanged.addListener(on_storage_changed);
     chrome.permissions.onAdded.addListener(on_permissions_changed);
     chrome.permissions.onRemoved.addListener(on_permissions_changed);
 
     broker = new Broker("linux_entra_sso", on_broker_state_change);
-    notify_state_change(true);
+    accountManager = new AccountManager(broker);
+    Promise.all([
+        PLATFORM.update_host_permissions(),
+        policyManager.load_policies(),
+        accountManager.restore().then((active) => {
+            state_active = active;
+        }),
+    ]).then(() => {
+        broker.connect();
+        notify_state_change();
+    });
 
     chrome.runtime.onConnect.addListener((port) => {
         port_menu = port;
         port_menu.onMessage.addListener(on_message_menu);
-        notify_state_change(true);
         port_menu.onDisconnect.addListener(() => {
             port_menu = null;
         });
-    });
-
-    chrome.storage.local.get("ssostate", (data) => {
-        if (data.ssostate) {
-            state_active = data.ssostate.state;
-            if (state_active) {
-                accounts.active = new Account(data.ssostate.account);
-                ssoLog(
-                    "temporarily using last-known account: " +
-                        accounts.active.username(),
-                );
-            }
-            notify_state_change();
-        }
+        notify_state_change(true);
     });
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -14,10 +14,6 @@ let broker = null;
 let policyManager = null;
 let accountManager = null;
 
-let host_versions = {
-    native: null,
-    broker: null,
-};
 let initialized = false;
 let state_active = true;
 let port_menu = null;
@@ -108,8 +104,8 @@ function notify_state_change(ui_only = false) {
             : null,
         broker_online: broker.isRunning(),
         enabled: state_active,
-        host_version: host_versions.native,
-        broker_version: host_versions.broker,
+        host_version: PLATFORM.host_versions.native,
+        broker_version: PLATFORM.host_versions.broker,
         sso_url: PLATFORM.getSsoUrl(),
         gpo_update: gpo_update,
     });
@@ -133,9 +129,6 @@ async function on_broker_state_change(online) {
             await accountManager.loadAccounts();
             accountManager.persist(state_active);
             notify_state_change();
-        }
-        if (host_versions.native === null) {
-            host_versions = await broker.getVersion();
         }
     } else {
         ssoLog("lost connection to broker");
@@ -172,6 +165,9 @@ function on_startup() {
         }),
     ]).then(() => {
         broker.connect();
+        PLATFORM.setup(broker).then(() => {
+            notify_state_change(true);
+        });
         notify_state_change();
     });
 

--- a/src/broker.js
+++ b/src/broker.js
@@ -40,14 +40,19 @@ export class RpcHandlerQueue {
 }
 
 export class Broker {
+    #name = null;
     #notify_fn = null;
     #port_native = null;
     #rpc_queue = new RpcHandlerQueue();
     #online = false;
 
     constructor(name, state_change_fn) {
+        this.#name = name;
         this.#notify_fn = state_change_fn;
-        this.#port_native = chrome.runtime.connectNative(name);
+    }
+
+    connect() {
+        this.#port_native = chrome.runtime.connectNative(this.#name);
         this.#port_native.onDisconnect.addListener(() => {
             this.#port_native = null;
             if (chrome.runtime.lastError) {

--- a/src/platform-abstraction.js
+++ b/src/platform-abstraction.js
@@ -8,6 +8,11 @@ export class Platform {
 
     browser;
 
+    host_versions = {
+        native: null,
+        broker: null,
+    };
+
     /* references needed for PRT injection */
     broker = null;
     account = null;
@@ -20,6 +25,13 @@ export class Platform {
          * must have access to both the requested URL and its initiator.
          */
         this.well_known_app_filters = [Platform.SSO_URL + "/*"];
+    }
+
+    /**
+     * Load platform information from backend.
+     */
+    async setup(broker) {
+        this.host_versions = await broker.getVersion();
     }
 
     setIconDisabled() {

--- a/src/platform-abstraction.js
+++ b/src/platform-abstraction.js
@@ -4,11 +4,23 @@
  */
 
 export class Platform {
+    static SSO_URL = "https://login.microsoftonline.com";
+
     browser;
 
     /* references needed for PRT injection */
     broker = null;
     account = null;
+    well_known_app_filters = [];
+
+    constructor() {
+        /*
+         * The WebRequest API operates on allowed URLs only.
+         * To intercept a sub-resource request (e.g. from an iframe), the extension
+         * must have access to both the requested URL and its initiator.
+         */
+        this.well_known_app_filters = [Platform.SSO_URL + "/*"];
+    }
 
     setIconDisabled() {
         chrome.action.setIcon({
@@ -17,6 +29,10 @@ export class Platform {
                 128: "/icons/linux-entra-sso_128.png",
             },
         });
+    }
+
+    getSsoUrl() {
+        return Platform.SSO_URL;
     }
 
     update_request_handlers(enabled, account, broker) {

--- a/src/platform-abstraction.js
+++ b/src/platform-abstraction.js
@@ -39,4 +39,9 @@ export class Platform {
         this.broker = broker;
         this.account = account;
     }
+
+    async update_host_permissions() {
+        const currentPermissions = await chrome.permissions.getAll();
+        this.well_known_app_filters = currentPermissions.origins;
+    }
 }

--- a/src/platform-abstraction.js
+++ b/src/platform-abstraction.js
@@ -3,6 +3,8 @@
  * SPDX-FileCopyrightText: Copyright 2025 Siemens
  */
 
+import { Deferred } from "./utils.js";
+
 export class Platform {
     static SSO_URL = "https://login.microsoftonline.com";
 
@@ -17,6 +19,7 @@ export class Platform {
     broker = null;
     account = null;
     well_known_app_filters = [];
+    sso_url_permitted = true;
 
     constructor() {
         /*
@@ -55,5 +58,16 @@ export class Platform {
     async update_host_permissions() {
         const currentPermissions = await chrome.permissions.getAll();
         this.well_known_app_filters = currentPermissions.origins;
+
+        // check if we have access to the SSO url
+        let dfd = new Deferred();
+        const permissionsToCheck = {
+            origins: [Platform.SSO_URL + "/*"],
+        };
+        chrome.permissions.contains(permissionsToCheck).then((result) => {
+            this.sso_url_permitted = result;
+            dfd.resolve();
+        });
+        await dfd.promise;
     }
 }

--- a/src/policy.js
+++ b/src/policy.js
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: MPL-2.0
+ * SPDX-FileCopyrightText: Copyright 2025 Siemens
+ */
+
+import { ssoLog, Deferred } from "./utils.js";
+
+export class PolicyManager {
+    static MANAGED_POLICIES_KEY = "wellKnownApps";
+    #apps = null;
+
+    async load_policies() {
+        let dfd = new Deferred();
+        chrome.storage.managed.get(
+            PolicyManager.MANAGED_POLICIES_KEY,
+            (data) => {
+                if (
+                    typeof data === "object" &&
+                    data.hasOwnProperty("wellKnownApps")
+                ) {
+                    this.#apps = { ...data.wellKnownApps };
+                    ssoLog("managed policies loaded");
+                }
+                dfd.resolve();
+            },
+        );
+        return dfd.promise;
+    }
+
+    getPolicyUpdate(active_app_filters) {
+        function matches_filter(app, policy) {
+            return (
+                app.replace("*://", "https://") == "https://" + policy + "/*"
+            );
+        }
+
+        const catch_all = active_app_filters.find((value) =>
+            matches_filter(value, "*"),
+        );
+        let gpo_update = {
+            pending: false,
+            filters_to_add: [],
+            filters_to_remove: [],
+            has_catch_all: catch_all !== undefined,
+            apps_managed: this.#apps,
+        };
+        if (this.#apps === null) return gpo_update;
+
+        if (gpo_update.has_catch_all) {
+            gpo_update.filters_to_remove.push(catch_all);
+            gpo_update.pending = true;
+        }
+        for (const [app, enabled] of Object.entries(this.#apps)) {
+            let filter = active_app_filters.find((value) =>
+                matches_filter(value, app),
+            );
+            if (!enabled && filter !== undefined) {
+                gpo_update.filters_to_remove.push(filter);
+                gpo_update.pending = true;
+            } else if (enabled && filter === undefined) {
+                gpo_update.filters_to_add.push("https://" + app + "/*");
+                gpo_update.pending = true;
+            }
+        }
+
+        return gpo_update;
+    }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,20 @@ export function ssoLogError(message) {
     console.error("[Linux Entra SSO] " + message);
 }
 
+export async function load_icon(path, width) {
+    const response = await fetch(chrome.runtime.getURL(path));
+    let imgBitmap = await createImageBitmap(await response.blob(), {
+        resizeWidth: width,
+        resizeHeight: width,
+    });
+    let canvas = new OffscreenCanvas(width, width);
+    let ctx = canvas.getContext("2d");
+    ctx.save();
+    ctx.drawImage(imgBitmap, 0, 0);
+    ctx.restore();
+    return ctx.getImageData(0, 0, width, width);
+}
+
 /**
  * Promise that can externally be resolved or rejected.
  */


### PR DESCRIPTION
These changes bring us closer to what the Edge browser is sending to the broker. We are still not fully there, but this is as far as I was able to deduce things from the official docs.

One parameter is missing, though. If someone has an idea where this data comes from (not always set), I'm happy to add it as well.

```json
"authParameters": { "requestOptions": [202, 205] }
```

Apart from that, we now support the silent token refresh of well-known apps. For that, the app URLs must be listed in the `host_permissions`. This is due to a requirement of the `webRequest` and `delarativeNetRequest` API that only operates on whitelisted URLs (the one in the browser bar), even if the `sub_frame` requests targets an already listed page.