### PR TITLE
ci: do not auto publish on CWS on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,3 +117,4 @@ jobs:
           client-id: ${{ secrets.CWS_CLIENT_ID }}
           client-secret: ${{ secrets.CWS_CLIENT_SECRET }}
           refresh-token: ${{ secrets.CWS_REFRESH_TOKEN }}
+          publish: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,4 +64,5 @@ The creation of public releases is a partially automated process:
 4. add release-notes to public release
 5. manually inspect signed xpi (double check)
 6. merge auto-created MR to enroll Firefox update manifest
-7. wait for CWS to review and sign extension, upload `.crx` to releases page
+7. publish CWS upload (answer questions on permission changes)
+8. wait for CWS to review and sign extension, upload `.crx` to releases page


### PR DESCRIPTION
The CWS is very strict about changes in the manifest file (especially permission related changes). The need for the changes often explicitly needs to be explained before being allowed to publish (and starting the CWS review process). By automatically trying to publish, the CI step fails in this case, marking the CI of the git tag as failed.

As this is somehow expected behavior, we no longer automatically publish, but just upload to the CWS. Then, the maintainers can inspect the initial report, answer the questions and publish manually. We further document this process in the CONTRIBUTING guide.