### PR TITLE
docs: describe how to use the extension in thunderbird

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 
 This browser extension uses a locally running Microsoft Identity Broker to authenticate the current user on Microsoft Entra ID on Linux devices.
 By that, also sites behind conditional access policies can be accessed.
-The extension is written for Firefox but provides a limited support for Google Chrome (and Chromium).
+The extension is written for Firefox but provides a limited support for Google Chrome, Chromium and Thunderbird.
 
 ## Pre-conditions
 
@@ -24,7 +24,7 @@ The extension requires [PyGObject](https://pygobject.gnome.org/) and [pydbus](ht
 - On Arch Linux: `sudo pacman -S python-gobject python-pydbus`
 - If you are using a Python version manager such as `asdf` you must install the Python packages manually: `pip install PyGObject pydbus`
 
-### Firefox: Signed Version from GitHub Releases
+### Firefox & Thunderbird: Signed Version from GitHub Releases
 
 You can download a **signed version** of the browser extension directly from our [GitHub Releases](https://github.com/siemens/linux-entra-sso/releases).
 
@@ -48,6 +48,8 @@ $ make local-install-firefox
 3. Download the extension file:
 
 Get the `linux_entra_sso-<version>.xpi` file from the [project's releases page](https://github.com/siemens/linux-entra-sso/releases).
+
+> If you are installing for Thunderbird, right-click the link and select "Save Link As..." to avoid installing it in Firefox.
 
 4. Enable required permissions:
 

--- a/background.js
+++ b/background.js
@@ -32,8 +32,22 @@ function ssoLogError(message) {
     console.error("[Linux Entra SSO] " + message);
 }
 
-function isFirefox() {
-    return typeof browser !== "undefined";
+function getBrowser() {
+    let userAgent = navigator.userAgent.toLowerCase();
+
+    if (userAgent.includes("firefox")) {
+        return "Firefox";
+    } else if (userAgent.includes("thunderbird")) {
+        return "Thunderbird";
+    } else if (userAgent.includes("chrome")) {
+        return "Chrome";
+    } else {
+        return "Unknown";
+    }
+}
+
+function isFirefoxLike() {
+    return ["Firefox", "Thunderbird"].includes(getBrowser());
 }
 
 /*
@@ -92,7 +106,7 @@ function update_ui() {
         return;
     }
     /* inactive states */
-    if (isFirefox()) {
+    if (isFirefoxLike()) {
         chrome.action.setIcon({
             path: "icons/linux-entra-sso.svg",
         });
@@ -163,7 +177,7 @@ function update_handlers_chrome() {
 
 function update_handlers() {
     ssoLog("update handlers");
-    if (isFirefox()) {
+    if (isFirefoxLike()) {
         update_handlers_firefox();
     } else {
         update_handlers_chrome();

--- a/background.js
+++ b/background.js
@@ -82,7 +82,12 @@ function update_ui() {
     chrome.action.enable();
     if (is_operational()) {
         let imgdata = {};
-        let icon_title = "EntraID SSO: " + accounts.active.username;
+        let icon_title = accounts.active.username;
+
+        // shorten the title a bit
+        if (getBrowser() == "Thunderbird")
+            icon_title = icon_title.split("@")[0];
+
         let color = null;
         chrome.action.setTitle({
             title: icon_title,
@@ -91,7 +96,6 @@ function update_ui() {
         if (!accounts.active.avatar_imgdata) return;
         if (!broker_online) {
             color = "#cc0000";
-            icon_title += " (offline)";
         }
         for (const r of [16, 32, 48]) {
             imgdata[r] = decorate_avatar(
@@ -127,6 +131,8 @@ function update_ui() {
     if (port_native === null) {
         title = "EntraID SSO disabled (no connection to host application)";
     }
+    // We have limited space on Thunderbird, hence shorten the title
+    if (getBrowser() == "Thunderbird") title = "EntraID SSO disabled";
     chrome.action.setTitle({ title: title });
 }
 


### PR DESCRIPTION
The Firefox version of the extension also works in Thunderbird (without any modifications). By that, the device trust can also be added to tokens requested via OIDC for backends like IMAP, SMTP and EWS.

We add a note about this to the README.