### PR TITLE
fix: notify state change only after broker is initialized

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -284,9 +284,9 @@ function on_startup() {
     }
     initialized = true;
     ssoLog("start linux-entra-sso on " + PLATFORM.browser);
-    notify_state_change(true);
 
     broker = new Broker("linux_entra_sso", on_broker_state_change);
+    notify_state_change(true);
 
     chrome.runtime.onConnect.addListener((port) => {
         port_menu = port;


### PR DESCRIPTION
As the notify_state_change accesses the broker object to check if the connection is running, we also need to instantiate the broker first. Currently, the extension fails to load, as the broker object is null at this point in time. This obvious error looks like a rebase artifact, which was introduced in da8b99c.

Fixes: da8b99c ("refactor: move native messaging to separate module")