### PR TITLE
chore(thunderbird): set application id

### DIFF
--- a/.pages/thunderbird/updates.json
+++ b/.pages/thunderbird/updates.json
@@ -1,6 +1,6 @@
 {
   "addons": {
-    "linux-entra-sso@example.com": {
+    "@linux-entra-sso.tb": {
       "updates": [
       ]
     }

--- a/platform/firefox/linux_entra_sso.json
+++ b/platform/firefox/linux_entra_sso.json
@@ -4,6 +4,7 @@
     "path": "/usr/local/lib/linux-entra-sso/linux-entra-sso.py",
     "type": "stdio",
     "allowed_extensions": [
-        "linux-entra-sso@example.com"
+        "linux-entra-sso@example.com",
+        "@linux-entra-sso.tb"
     ]
 }

--- a/platform/thunderbird/manifest.json
+++ b/platform/thunderbird/manifest.json
@@ -8,7 +8,7 @@
     },
     "browser_specific_settings": {
         "gecko": {
-            "id": "linux-entra-sso@example.com",
+            "id": "@linux-entra-sso.tb",
             "strict_min_version": "128.0",
             "update_url": "https://siemens.github.io/linux-entra-sso/thunderbird/updates.json"
         }


### PR DESCRIPTION
As told by Mozilla [1], we should use a distinct application id for the thunderbird version. This also gives us the chance to select a new application id in the now preferred format (@string instead of email) [2].

To keep the id similar to the previous one, we now use "@linux-entra-sso.tb". Note, that this id cannot be changed later on without creating a "new" extension entry.

[1] https://discourse.mozilla.org/t/listing-webextension-on-both-amo-and-addons-thunderbird-net/145536/3
[2] https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings