### PR TITLE
fix: only register handlers if operational

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -92,7 +92,7 @@ function notify_state_change(ui_only = false) {
     if (!ui_only && broker.isConnected()) {
         ssoLog("update handlers");
         PLATFORM.update_request_handlers(
-            state_active,
+            is_operational(),
             accountManager.getActive(),
             broker,
         );


### PR DESCRIPTION
We already distinguish the state is_operational (we have everything to perform SSO) and is_active, which just denotes that the user wants to use SSO (this does not mean all necessary pre-conditions are true).

For the request handlers, we need to check if we are operational. This bug usually was not critical, as later on we got proper account data and re-initialized the request handlers.

Fixes: febc859 ("refactor(accounts): move account handling logic ...")