### PR TITLE
chore(thunderbird): show extension in account setup dialog

### DIFF
--- a/platform/thunderbird/manifest.json
+++ b/platform/thunderbird/manifest.json
@@ -22,7 +22,8 @@
             "calendar",
             "addressbook",
             "tasks",
-            "settings"
+            "settings",
+            "default"
         ]
     },
     "background": {


### PR DESCRIPTION
When setting up an account via the "Account Setup" dialog, the extension currently is hidden. Unfortunately this dialog has no dedicated space assigned, so we need to add the "default" space to show it there.

Especially in this dialog it is critical to show the extension so the user can select the correct SSO account and check if the SSO is enabled.