### PR TITLE
feat: keep device information up to date

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -102,6 +102,11 @@ function notify_state_change(ui_only = false) {
         );
     }
     if (port_menu === null) return;
+    deviceManager.updateDeviceInfo().then((updated) => {
+        if (updated) {
+            notify_state_change(true);
+        }
+    });
     port_menu.postMessage({
         event: "stateChanged",
         accounts: accountManager.getRegistered().map((a) => a.toMenuObject()),

--- a/src/device.js
+++ b/src/device.js
@@ -16,12 +16,27 @@ export class Device {
 }
 
 export class DeviceManager {
+    static DEVICE_REFRESH_INTERVAL_MIN = 30;
+
     #am = null;
+    #last_refresh = 0;
     device = null;
 
     constructor(account_manager) {
         this.#am = account_manager;
         this.device = null;
+    }
+
+    async updateDeviceInfo() {
+        if (
+            Date.now() <
+            this.#last_refresh +
+                DeviceManager.DEVICE_REFRESH_INTERVAL_MIN * 60 * 1000
+        ) {
+            return false;
+        }
+        await this.loadDeviceInfo();
+        return true;
     }
 
     async loadDeviceInfo() {
@@ -50,7 +65,9 @@ export class DeviceManager {
             return;
         }
         const data = await response.json();
+        this.#last_refresh = Date.now();
         this.device = new Device(data.displayName, data.isCompliant);
+        ssoLog("updated device information");
     }
 
     getDevice() {


### PR DESCRIPTION
Previously, we only fetched the device information (including the compliance state) once when loading the accounts. However the compliance state can change over time (it is updated approximately every 1 hour). To always show an up-to-date version, we refresh it if it is older than 30 mins. To avoid frequent API calls to MS, we perform the refresh lazily when opening the UI.