### PR TITLE
chore(ui): use better rendering unicode char for state icons

### DIFF
--- a/popup/menu.html
+++ b/popup/menu.html
@@ -59,7 +59,7 @@ SPDX-FileCopyrightText: Copyright 2024 Siemens AG
                         >disabled</span
                     >
                     <span class="right">
-                        <span class="state-connected-icon">&#9210;</span>
+                        <span class="state-connected-icon">&#9679;</span>
                         <span id="current-url"></span>
                     </span>
                 </div>
@@ -68,7 +68,7 @@ SPDX-FileCopyrightText: Copyright 2024 Siemens AG
                     <span class="right">
                         <span id="device-name"></span>
                         &#40;
-                        <span class="state-compliant-icon">&#9210;</span>
+                        <span class="state-compliant-icon">&#9679;</span>
                         <span id="state-compliant-value">unknown</span>&#41;
                     </span>
                 </div>
@@ -79,7 +79,7 @@ SPDX-FileCopyrightText: Copyright 2024 Siemens AG
                     <span class="right">
                         <span id="broker-version"></span>
                         &#40;
-                        <span class="state-connected-icon">&#9210;</span>
+                        <span class="state-connected-icon">&#9679;</span>
                         <span id="broker-state-value">unknown</span>&#41;
                     </span>
                 </div>


### PR DESCRIPTION
Seems that both FF and Chrome may render the previously used unicode char with different colors than desired and sometimes even in different shapes. Use "Black Circle" instead.

Fixes #101