### PR TITLE
chore(ui): set font family of body element

### DIFF
--- a/popup/menu.css
+++ b/popup/menu.css
@@ -8,7 +8,7 @@
     --font-size-smaller: calc(var(--font-size) - 1px);
     --font-size-xsmall: calc(var(--font-size) - 3px);
     --font-size-larger: 15px;
-    --font-family: Inter, sans-serif;
+    --font-family: Arial, Helvetica, Sans-Serif;
     --monospace-size: 12px;
 }
 
@@ -84,6 +84,7 @@ body {
 
 body {
     background-color: var(--surface-0);
+    font-family: var(--font-family);
 }
 
 .entity {


### PR DESCRIPTION
By explicitly setting a font-family for the body element, we align the looking of the extension across browsers. This further helps to align the rendering of our unicode indicator dot, which got improved in 2e3f220 but looks quite big on some systems without pinning the font.

We further decide to use a sans-serif font (as chromium anyways used) for a cleaner rendering of small texts.

Xref: #101