### PR TITLE
fix: do not recurse on error when fetching device state information

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -103,6 +103,7 @@ function notify_state_change(ui_only = false) {
     }
     if (port_menu === null) return;
     deviceManager.updateDeviceInfo().then((updated) => {
+        /* only notify on success to avoid indefinite recursion as errors are not cached */
         if (updated) {
             notify_state_change(true);
         }


### PR DESCRIPTION
As part of the notify_state_change, we check if our device information is up-to-date and refresh it if needed. This refresh triggers a new notify_state_change event in case the device state was updated. As we previously considered errors as device state updates but did not set the rate-limiting for subsequent requests, the call ended in an indefinite recursion, leading an eventual OOM of the browser extension.

Not caching / rate-limiting errors is reasonable, as we need to deal with sporadic errors from flaky networks. However, errors might also be permanent, e.g. due to incorrect device identifiers, crashes of the MS broker or other user errors (like not having the needed native dependencies installed). As we cannot distinguish these errors, we now follow the simple approach to not treat errors during the update of the device info as "new device state". By that, we don't recurse in this path while still refreshing the device state on user interaction (e.g. when opening the popup).

Fixes: cff7785 ("feat: keep device information up to date")
Closes: #106