### PR TITLE
docs: clarify which broker versions are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The extension is written for Firefox but provides a limited support for Google C
 > This extension will only work on intune-enabled Linux devices. Please double
 > check this by running the `intune-portal` application and check if your user
 > is logged in (after clicking `sign-in`).
+>
+> Only `microsoft-identity-broker` version 2.0.1 and himmelblau are supported.
+> Support for later broker versions is being worked on.
 
 ## Installation
 


### PR DESCRIPTION
As there are already more recent versions of the
microsoft-identity-broker and we got a first issue regarding incompatibilities, we document what we support.

A first try at fixing the compatibility issues was not successful, so we better add documentation until this is sorted out.

Xref: #108