### PR TITLE
fix(gitignore): Ignore the Debian directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 
 Linux-Entra-SSO*.xpi
 __pycache__/
-build
+build/
+debuild.d/
+pkgs/


### PR DESCRIPTION
`make deb` creates two directories, which are missing from `.gitignore`. Add them.