### PR TITLE
style: Sort imports

### DIFF
--- a/linux-entra-sso.py
+++ b/linux-entra-sso.py
@@ -8,15 +8,16 @@
 # pylint: enable=invalid-name
 
 import argparse
-from enum import Enum
-import sys
+import ctypes
 import json
 import struct
+import sys
 import uuid
-import ctypes
+from enum import Enum
 from signal import SIGINT
-from threading import Thread, RLock
+from threading import RLock, Thread
 from xml.etree import ElementTree as ET
+
 from gi.repository import GLib
 from pydbus import SessionBus
 from pydbus.proxy import CompositeInterface


### PR DESCRIPTION
While working on our internal Debian package I notices, that the `import` statements in `linux-entra-sso.py` are not sorted.

Sort import statements like `isort` or `ruff check --select I --fix` would do:
- `import` before `from … import …`.
- "Standard Python library" before "External modules/packages".