### PR TITLE
Revert "docs: clarify which broker versions are supported"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ The extension is written for Firefox but provides a limited support for Google C
 > This extension will only work on intune-enabled Linux devices. Please double
 > check this by running the `intune-portal` application and check if your user
 > is logged in (after clicking `sign-in`).
->
-> Only `microsoft-identity-broker` version 2.0.1 and himmelblau are supported.
-> Support for later broker versions is being worked on.
 
 ## Installation
 


### PR DESCRIPTION
This reverts commit f25cc1563c7cfb6cb352311899c37ca9c4ac31b8.

Support for broker versions 2.0.1+ has been integrated and will be part of the next release.