### PR TITLE
fix: replace PR_SET_PDEATHSIG with daemon thread to prevent accidental kills

### DIFF
--- a/linux-entra-sso.py
+++ b/linux-entra-sso.py
@@ -8,13 +8,12 @@
 # pylint: enable=invalid-name
 
 import argparse
-import ctypes
 import json
 import struct
 import sys
 import uuid
 from enum import Enum
-from signal import SIGINT
+
 from threading import RLock, Thread
 from xml.etree import ElementTree as ET
 
@@ -34,8 +33,6 @@ EDGE_BROWSER_CLIENT_ID = "d7b530a4-7680-4c23-a8bf-c52c121d2e87"
 # dbus start service reply codes
 START_REPLY_SUCCESS = 1
 START_REPLY_ALREADY_RUNNING = 2
-# prctl constants
-PR_SET_PDEATHSIG = 1
 
 # stripped down version of the broker dbus interface,
 # as brokers > 2.0.1 do not implement introspection
@@ -281,20 +278,14 @@ def run_as_native_messaging():
         loop = GLib.MainLoop()
         loop.run()
 
-    def register_terminate_with_parent():
-        libc = ctypes.CDLL("libc.so.6")
-        libc.prctl(PR_SET_PDEATHSIG, SIGINT, 0, 0, 0)
-
     print("Running as native messaging instance.", file=sys.stderr)
     print("For interactive mode, start with --interactive", file=sys.stderr)
 
-    # on chrome and chromium, the parent process does not reliably
-    # terminate the process when the parent process is killed.
-    register_terminate_with_parent()
-
     ssomib = SsoMib(daemon=True)
     ssomib.on_broker_state_changed(notify_state_change)
-    monitor = Thread(target=run_dbus_monitor)
+    # daemon=True is critical: without it, the GLib main loop thread
+    # keeps the process alive as an orphan after the browser closes stdin.
+    monitor = Thread(target=run_dbus_monitor, daemon=True)
     monitor.start()
     while True:
         received_message = NativeMessaging.get_message()


### PR DESCRIPTION
## Summary
Fixes #109 (possibly #127 too?)

`PR_SET_PDEATHSIG` (added in 407d493) fires [on **thread** death, not process death](https://man7.org/linux/man-pages/man2/pr_set_pdeathsig.2const.html). When Firefox runs as a Snap, the native messaging host is spawned via the `xdg-desktop-portal` proxy, and the portal's threadpool recycling spuriously delivers the signal; causing a SIGINT in the host process while Firefox is still running.

This problem is further exaggerated/hidden by the non-daemon thread spawned for the GLib main loop. The host process receives SIGINT, and terminates the "main" command processing loop. But Python hangs on shutdown waiting for the GLib loop thread to terminate. If we mark that thread as `daemon=True`, the thread is automatically terminated on shutdown (when the stdio is closed).

In practice, this issue causes Microsoft login requests to sometimes hang indefinitely in Firefox Snap, because the Firefox SSO extension writes to the native message socket, the process is still running in a zombie state, but no longer listening.

The original orphan-process problem under Chrome was actually caused by the non-daemon GLib main loop thread keeping the process alive after the browser closes stdin. Making the monitor thread a daemon thread addresses this root cause directly, without the `PR_SET_PDEATHSIG` pitfall.

## Changes

- Remove `PR_SET_PDEATHSIG`/`prctl` setup (`register_terminate_with_parent`)
- Mark the D-Bus monitor thread as `daemon=True` so the process exits cleanly when stdin is closed

## Testing

- **Firefox Snap (Ubuntu 24.04):** Microsoft login pages no longer hang; the SSO extension's native messaging header lookup completes successfully
- **Chrome:** Confirmed no orphan `linux-entra-sso.py` processes remain after closing the browser. Orphan processes are reproducible without the daemon thread change.
- Other browsers untested due to not having them available
