### PR TITLE
ci: update checkout action to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  WEB_EXT_VERS: 8.9.0
+  WEB_EXT_VERS: 10.1.0
 
 jobs:
   reuse-and-codestyle:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -56,7 +56,7 @@ jobs:
       attestations: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -75,21 +75,21 @@ jobs:
           npx web-ext@${{ env.WEB_EXT_VERS }} lint --source-dir build/thunderbird --self-hosted
 
       - name: upload Firefox and Thunderbird extension
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mozilla-xpi
           path: |
             build/**/*.xpi
 
       - name: upload chrome extension zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chrome-zip
           path: |
             build/chrome/
 
       - name: upload debian package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debian-package
           path: |

--- a/.github/workflows/deploy-update-manifest.yml
+++ b/.github/workflows/deploy-update-manifest.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
             pkgs/linux-entra-sso_*.deb
 
       - name: create release
-        uses: softprops/action-gh-release@a74c6b72af54cfa997e81df42d94703d6313a2d0 # v2.0.6
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: |
             build/linux_entra_sso-*.xpi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 permissions: {}
 
 env:
-  WEB_EXT_VERS: 8.9.0
+  WEB_EXT_VERS: 10.1.0
 
 jobs:
   release-extension:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: get git committer
         run: |
@@ -57,14 +57,14 @@ jobs:
             --filename '{name}-{version}.thunderbird.xpi'
 
       - name: upload firefox extension
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firefox-signed-xpi
           path: |
             build/linux_entra_sso-*.xpi
 
       - name: upload debian package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debian-package
           path: |


### PR DESCRIPTION
This fixes the Node 20 deprecation warning we see in CI runs and is good practice in general.