### PR TITLE
Support manifest v3 service worker lifecycle

### DIFF
--- a/platform/chrome/js/platform-chrome.js
+++ b/platform/chrome/js/platform-chrome.js
@@ -11,6 +11,11 @@ export class PlatformChrome extends Platform {
     #update_net_rules_cb = null;
 
     static CHROME_PRT_SSO_REFRESH_INTERVAL_MIN = 30;
+    /*
+     * PRT injection uses declarativeNetRequest, which does not require a
+     * running service worker, so the NM connection can idle out.
+     */
+    static KEEP_BROKER_CONNECTED = false;
 
     constructor() {
         super();

--- a/platform/chrome/js/platform-chrome.js
+++ b/platform/chrome/js/platform-chrome.js
@@ -8,9 +8,11 @@ import { ssoLog } from "./utils.js";
 
 export class PlatformChrome extends Platform {
     browser = "Chrome";
-    #update_net_rules_cb = null;
+    #broker = null;
+    #on_alarm_cb = null;
 
     static CHROME_PRT_SSO_REFRESH_INTERVAL_MIN = 30;
+    static PRT_SSO_REFRESH_ALARM = "prt-sso-refresh";
     /*
      * PRT injection uses declarativeNetRequest, which does not require a
      * running service worker, so the NM connection can idle out.
@@ -19,35 +21,51 @@ export class PlatformChrome extends Platform {
 
     constructor() {
         super();
+        /*
+         * Register the alarm listener synchronously during worker startup.
+         * Only top-level listeners can wake a suspended MV3 service worker,
+         * so this is required for the periodic PRT refresh to fire reliably.
+         */
+        this.#on_alarm_cb = this.#on_alarm.bind(this);
+        chrome.alarms.onAlarm.addListener(this.#on_alarm_cb);
     }
 
     update_request_handlers(enabled, account, broker) {
         super.update_request_handlers(enabled, account, broker);
-        this.#update_net_rules_cb = this.#update_net_rules.bind(this, broker);
+        this.#broker = broker;
         if (!enabled) {
-            chrome.alarms.onAlarm.removeListener(this.#update_net_rules_cb);
-            chrome.alarms.clear("prt-sso-refresh");
+            chrome.alarms.clear(PlatformChrome.PRT_SSO_REFRESH_ALARM);
             this.#clear_net_rules();
             return;
         }
-        this.#ensure_refresh_alarm("prt-sso-refresh");
+        this.#ensure_refresh_alarm(PlatformChrome.PRT_SSO_REFRESH_ALARM);
         this.#update_net_rules(broker);
     }
 
     /*
-     * Ensure the alarm is armed exactly once.
+     * Called when the refresh alarm fires (possibly waking the worker).
+     * If the broker/account are not ready yet, the regular startup flow will
+     * refresh the rules, so we can safely skip here.
+     */
+    #on_alarm(alarm) {
+        if (alarm.name !== PlatformChrome.PRT_SSO_REFRESH_ALARM) return;
+        if (!this.#broker || !this.account) return;
+        this.#update_net_rules(this.#broker);
+    }
+
+    /*
+     * Ensure the alarm is armed with the configured period. If an alarm with
+     * a different period already exists, it is re-created.
      */
     async #ensure_refresh_alarm(alarm_id) {
+        const period = PlatformChrome.CHROME_PRT_SSO_REFRESH_INTERVAL_MIN;
         const alarm = await chrome.alarms.get(alarm_id);
-        if (!alarm) {
-            await chrome.alarms.create(alarm_id, {
-                periodInMinutes:
-                    PlatformChrome.CHROME_PRT_SSO_REFRESH_INTERVAL_MIN,
-            });
+        if (alarm && alarm.periodInMinutes === period) {
+            return;
         }
-        if (!chrome.alarms.onAlarm.hasListener(this.#update_net_rules_cb)) {
-            chrome.alarms.onAlarm.addListener(this.#update_net_rules_cb);
-        }
+        await chrome.alarms.create(alarm_id, {
+            periodInMinutes: period,
+        });
     }
 
     async #clear_net_rules() {
@@ -59,7 +77,7 @@ export class PlatformChrome extends Platform {
         });
     }
 
-    async #update_net_rules(broker, e) {
+    async #update_net_rules(broker) {
         ssoLog("update network rules");
         let prt = undefined;
         try {

--- a/platform/firefox/js/platform-firefox.js
+++ b/platform/firefox/js/platform-firefox.js
@@ -8,6 +8,12 @@ import { ssoLog } from "./utils.js";
 
 export class PlatformFirefox extends Platform {
     browser = "Firefox";
+    /*
+     * We use a blocking webRequest handler for PRT injection, which requires a
+     * running service worker. Keep the NM connection alive to prevent the MV3
+     * worker from being shut down.
+     */
+    static KEEP_BROKER_CONNECTED = true;
     /* PRT injection state */
     #on_before_send_headers = null;
     #broker = null;

--- a/src/account.js
+++ b/src/account.js
@@ -149,6 +149,8 @@ export class Account {
 export class AccountManager {
     #registered = [];
     #queried = false;
+    /* SSO is active unless the user explicitly logged out */
+    #active = true;
     /* in-flight token requests, keyed by username, to dedup concurrent calls */
     #token_requests = new Map();
 
@@ -165,6 +167,17 @@ export class AccountManager {
 
     getActive() {
         return this.#registered.find((a) => a.active);
+    }
+
+    /**
+     * @returns if SSO is active (i.e. the user did not explicitly log out)
+     */
+    isActive() {
+        return this.#active;
+    }
+
+    setActive(active) {
+        this.#active = active;
     }
 
     getRegistered() {
@@ -210,7 +223,14 @@ export class AccountManager {
         // corresponding one from the broker as active.
         const last_username = this.getActive()?.username();
         this.#registered = _accounts;
-        if (last_username && this.selectAccount(last_username)) {
+
+        /* we successfully got account data from the broker */
+        this.#queried = true;
+
+        // only auto-select an account if the user did not explicitly disable SSO
+        if (!this.#active) {
+            ssoLog("SSO is disabled, not selecting an account");
+        } else if (last_username && this.selectAccount(last_username)) {
             ssoLog(
                 "select previously used account: " +
                     this.getActive().username(),
@@ -219,9 +239,6 @@ export class AccountManager {
             this.selectAccount();
             ssoLog("select first account: " + this.getActive().username());
         }
-
-        /* we successfully got account data from the broker */
-        this.#queried = true;
 
         await Promise.all(
             this.#registered.map((a) => this.loadProfilePicture(broker, a)),
@@ -332,7 +349,8 @@ export class AccountManager {
         }
         /* restored from session */
         if (this.#registered.length > 0) {
-            return this.getActive() != null;
+            this.#active = this.getActive() != null;
+            return;
         }
 
         /* no accounts in session, try restore from local storage */
@@ -340,9 +358,11 @@ export class AccountManager {
         if (!data.ssostate) {
             ssoLog("no preserved state found");
             // if the SSO is not explicitly disabled, we assume it is on.
-            return true;
+            this.#active = true;
+            return;
         }
         const state_active = data.ssostate.state;
+        this.#active = state_active;
         if (state_active && data.ssostate.accounts) {
             this.#registered = data.ssostate.accounts.map((a) =>
                 Account.fromSerial(a),
@@ -356,6 +376,5 @@ export class AccountManager {
                 );
             }
         }
-        return state_active;
     }
 }

--- a/src/account.js
+++ b/src/account.js
@@ -123,18 +123,25 @@ export class Account {
         return ctx.getImageData(0, 0, width, width);
     }
 
-    toSerial() {
-        return {
+    toSerial(with_secrets = false) {
+        const serial = {
             broker_obj: this.brokerObject(),
             active: this.active,
             avatar: this.avatar,
         };
+        if (with_secrets) {
+            serial.access_token = this.access_token;
+            serial.access_token_exp = this.access_token_exp;
+        }
+        return serial;
     }
 
     static fromSerial(serial) {
         let acc = new Account(serial.broker_obj);
         acc.active = serial.active;
         acc.avatar = serial.avatar ?? null;
+        acc.access_token = serial.access_token ?? null;
+        acc.access_token_exp = serial.access_token_exp ?? 0;
         return acc;
     }
 }
@@ -283,11 +290,34 @@ export class AccountManager {
                 ? this.#registered.map((a) => a.toSerial())
                 : [],
         };
-        return chrome.storage.local.set({ ssostate });
+        const appstate = {
+            broker_queried: this.#queried,
+            accounts: this.#registered.map((a) => a.toSerial(true)),
+        };
+        return Promise.all([
+            chrome.storage.local.set({ ssostate }),
+            chrome.storage.session.set({ account_manager: appstate }),
+        ]);
     }
 
     async restore() {
-        const data = await chrome.storage.local.get("ssostate");
+        const [data, sessionData] = await Promise.all([
+            chrome.storage.local.get("ssostate"),
+            chrome.storage.session.get("account_manager"),
+        ]);
+        if (sessionData.account_manager) {
+            this.#queried = sessionData.account_manager.broker_queried ?? false;
+            this.#registered =
+                sessionData.account_manager.accounts.map((a) =>
+                    Account.fromSerial(a),
+                ) ?? [];
+        }
+        /* restored from session */
+        if (this.#registered.length > 0) {
+            return this.getActive() != null;
+        }
+
+        /* no accounts in session, try restore from local storage */
         let active_acc = undefined;
         if (!data.ssostate) {
             ssoLog("no preserved state found");

--- a/src/account.js
+++ b/src/account.js
@@ -149,6 +149,8 @@ export class Account {
 export class AccountManager {
     #registered = [];
     #queried = false;
+    /* in-flight token requests, keyed by username, to dedup concurrent calls */
+    #token_requests = new Map();
 
     hasAccounts() {
         return this.#registered.length != 0;
@@ -230,6 +232,22 @@ export class AccountManager {
         if (Date.now() + TOKEN_MIN_VALIDITY_MS < account.access_token_exp) {
             return account.access_token;
         }
+        const username = account.username();
+        /* coalesce concurrent requests for the same account */
+        let request = this.#token_requests.get(username);
+        if (request) {
+            return request;
+        }
+        request = this.#acquireToken(broker, account);
+        this.#token_requests.set(username, request);
+        try {
+            return await request;
+        } finally {
+            this.#token_requests.delete(username);
+        }
+    }
+
+    async #acquireToken(broker, account) {
         try {
             const graph_token = await broker.acquireTokenSilently(account);
             ssoLog("API token acquired for " + account.username());

--- a/src/account.js
+++ b/src/account.js
@@ -124,12 +124,17 @@ export class Account {
     }
 
     toSerial() {
-        return { broker_obj: this.brokerObject(), active: this.active };
+        return {
+            broker_obj: this.brokerObject(),
+            active: this.active,
+            avatar: this.avatar,
+        };
     }
 
     static fromSerial(serial) {
         let acc = new Account(serial.broker_obj);
         acc.active = serial.active;
+        acc.avatar = serial.avatar ?? null;
         return acc;
     }
 }

--- a/src/account.js
+++ b/src/account.js
@@ -10,7 +10,9 @@ const TOKEN_MIN_VALIDITY_MS = 60 * 1000;
 
 export class Account {
     #broker_obj = null;
+    /* ImageData cache for the tray icon (not serialized) */
     #avatar_imgdata = null;
+    /* circular avatar as a serializable data URL; null => default icon */
     avatar = null;
     active = false;
     access_token = null;
@@ -42,17 +44,31 @@ export class Account {
     }
 
     async getAvatarImgData() {
-        if (!this.#avatar_imgdata) {
+        if (this.#avatar_imgdata) {
+            return this.#avatar_imgdata;
+        }
+        if (!this.avatar) {
             this.#avatar_imgdata = await load_icon(
                 "/icons/profile-outline_48.png",
                 48,
             );
+            return this.#avatar_imgdata;
         }
+        /* derive ImageData from the serializable data URL */
+        const bitmap = await createImageBitmap(
+            await (await fetch(this.avatar)).blob(),
+        );
+        const canvas = new OffscreenCanvas(48, 48);
+        const ctx = canvas.getContext("2d");
+        ctx.drawImage(bitmap, 0, 0, 48, 48);
+        this.#avatar_imgdata = ctx.getImageData(0, 0, 48, 48);
         return this.#avatar_imgdata;
     }
 
-    setAvatarImgData(data) {
-        this.#avatar_imgdata = data;
+    setAvatar(dataUrl) {
+        this.avatar = dataUrl;
+        /* clear cache, will be rebuild on next getAvatarImgData */
+        this.#avatar_imgdata = null;
     }
 
     async getDecoratedAvatar(color, width) {
@@ -230,12 +246,10 @@ export class AccountManager {
             let avatar = await createImageBitmap(await response.blob());
             let canvas = new OffscreenCanvas(48, 48);
             let ctx = canvas.getContext("2d");
-            ctx.save();
             ctx.beginPath();
             ctx.arc(24, 24, 24, 0, Math.PI * 2, false);
             ctx.clip();
-            ctx.drawImage(avatar, 0, 0);
-            ctx.restore();
+            ctx.drawImage(avatar, 0, 0, 48, 48);
             /* serialize image to data URL (ugly, but portable) */
             let blob = await canvas.convertToBlob();
             const dataUrl = await new Promise((r) => {
@@ -243,12 +257,7 @@ export class AccountManager {
                 a.onload = r;
                 a.readAsDataURL(blob);
             }).then((e) => e.target.result);
-
-            /* store image data */
-            ctx.clearRect(0, 0, 48, 48);
-            ctx.drawImage(avatar, 0, 0, 48, 48);
-            account.setAvatarImgData(ctx.getImageData(0, 0, 48, 48));
-            account.avatar = dataUrl;
+            account.setAvatar(dataUrl);
         } else {
             ssoLog(
                 "Warning: Could not get profile picture of " +

--- a/src/background.js
+++ b/src/background.js
@@ -19,6 +19,7 @@ let deviceManager = null;
 let initialized = false;
 let state_active = true;
 let port_menu = null;
+let state_restored = false;
 
 /*
  * Check if all conditions for SSO are met
@@ -86,6 +87,9 @@ async function update_tray(action_needed) {
  * the menu about a state change.
  */
 function notify_state_change(ui_only = false) {
+    // on service worker startup, delay all updates until we restored
+    // the application state from storage.
+    if (!state_restored) return;
     const gpo_update = policyManager.getPolicyUpdate(
         PLATFORM.well_known_app_filters,
     );
@@ -186,6 +190,7 @@ function on_startup() {
         }),
         deviceManager.restore(),
     ]).then(() => {
+        state_restored = true;
         broker.connect();
         PLATFORM.setup(broker).then(() => {
             notify_state_change(true);

--- a/src/background.js
+++ b/src/background.js
@@ -171,7 +171,11 @@ function on_startup() {
     chrome.permissions.onAdded.addListener(on_permissions_changed);
     chrome.permissions.onRemoved.addListener(on_permissions_changed);
 
-    broker = new Broker("linux_entra_sso", on_broker_state_change);
+    broker = new Broker(
+        "linux_entra_sso",
+        on_broker_state_change,
+        PLATFORM.constructor.KEEP_BROKER_CONNECTED,
+    );
     accountManager = new AccountManager(broker);
     deviceManager = new DeviceManager(accountManager);
     Promise.all([

--- a/src/background.js
+++ b/src/background.js
@@ -17,7 +17,6 @@ let accountManager = null;
 let deviceManager = null;
 
 let initialized = false;
-let state_active = true;
 let port_menu = null;
 let state_restored = false;
 
@@ -25,7 +24,7 @@ let state_restored = false;
  * Check if all conditions for SSO are met
  */
 function is_operational() {
-    return state_active && accountManager.getActive();
+    return accountManager.isActive() && accountManager.getActive();
 }
 
 async function on_permissions_changed() {
@@ -67,7 +66,8 @@ async function update_tray(action_needed) {
     /* inactive states */
     PLATFORM.setIconDisabled();
     let title = "EntraID SSO disabled";
-    if (state_active) title = "EntraID SSO disabled (waiting for broker)";
+    if (accountManager.isActive())
+        title = "EntraID SSO disabled (waiting for broker)";
     if (accountManager.hasAccounts() == 0) {
         title = "EntraID SSO disabled (no accounts registered)";
     }
@@ -117,7 +117,7 @@ function notify_state_change(ui_only = false) {
         broker_online: broker.isRunning(),
         nm_connected: broker.isConnected(),
         device: deviceManager.getDevice(),
-        enabled: state_active,
+        enabled: accountManager.isActive(),
         host_version: PLATFORM.host_versions.native,
         broker_version: PLATFORM.host_versions.broker,
         sso_url: PLATFORM.getSsoUrl(),
@@ -127,11 +127,11 @@ function notify_state_change(ui_only = false) {
 
 async function on_message_menu(request) {
     if (request.command == "enable") {
-        state_active = true;
+        accountManager.setActive(true);
         const account = accountManager.selectAccount(request.username);
         if (account) ssoLog("select account " + account.username());
     } else if (request.command == "disable") {
-        state_active = false;
+        accountManager.setActive(false);
         accountManager.logout();
         ssoLog("disable SSO");
     }
@@ -185,9 +185,7 @@ function on_startup() {
     Promise.all([
         PLATFORM.update_host_permissions(),
         policyManager.load_policies(),
-        accountManager.restore().then((active) => {
-            state_active = active;
-        }),
+        accountManager.restore(),
         deviceManager.restore(),
     ]).then(() => {
         state_restored = true;

--- a/src/background.js
+++ b/src/background.js
@@ -103,6 +103,7 @@ function notify_state_change(ui_only = false) {
     deviceManager.updateDeviceInfo(broker).then((updated) => {
         /* only notify on success to avoid indefinite recursion as errors are not cached */
         if (updated) {
+            deviceManager.persist();
             notify_state_change(true);
         }
     });
@@ -142,6 +143,7 @@ async function on_broker_state_change(online) {
             await accountManager.loadAccounts(broker);
             accountManager.persist();
             await deviceManager.loadDeviceInfo(broker);
+            deviceManager.persist();
             notify_state_change();
         }
     } else {
@@ -178,6 +180,7 @@ function on_startup() {
         accountManager.restore().then((active) => {
             state_active = active;
         }),
+        deviceManager.restore(),
     ]).then(() => {
         broker.connect();
         PLATFORM.setup(broker).then(() => {

--- a/src/broker.js
+++ b/src/broker.js
@@ -40,18 +40,32 @@ export class RpcHandlerQueue {
 }
 
 export class Broker {
+    static IDLE_DISCONNECT_MS = 10 * 1000;
+
     #name = null;
     #notify_fn = null;
     #port_native = null;
     #rpc_queue = new RpcHandlerQueue();
-    #online = false;
+    /* assume the broker is running until we know */
+    #online = true;
+    /* track if the NM connection was successful */
+    #conn_error = false;
+    #idle_timer = null;
+    /* if set, the NM connection is kept alive permanently */
+    #keep_connected = false;
 
-    constructor(name, state_change_fn) {
+    constructor(name, state_change_fn, keep_connected = false) {
         this.#name = name;
         this.#notify_fn = state_change_fn;
+        this.#keep_connected = keep_connected;
     }
 
     connect() {
+        if (this.#port_native) {
+            this.#reset_idle_timer();
+            return;
+        }
+        this.#conn_error = false;
         this.#port_native = chrome.runtime.connectNative(this.#name);
         this.#port_native.onDisconnect.addListener(() => {
             this.#port_native = null;
@@ -60,6 +74,7 @@ export class Broker {
                     "Error in native application connection: " +
                         chrome.runtime.lastError.message,
                 );
+                this.#conn_error = true;
             } else {
                 ssoLogError("Native application connection closed.");
             }
@@ -68,23 +83,65 @@ export class Broker {
         this.#port_native.onMessage.addListener(
             this.#on_message_native.bind(this),
         );
+        this.#reset_idle_timer();
         ssoLog("connected to host tooling");
     }
 
+    disconnect() {
+        this.#clear_idle_timer();
+        if (!this.#port_native) return;
+
+        this.#port_native.disconnect();
+        this.#port_native = null;
+    }
+
+    /**
+     * Ensure we are connected to the broker and (re)start the
+     * inactivity timer. Must be called by every broker function.
+     */
+    #keep_alive() {
+        this.connect();
+        this.#reset_idle_timer();
+    }
+
+    #reset_idle_timer() {
+        this.#clear_idle_timer();
+        /* keep the connection alive to prevent the worker from shutting down */
+        if (this.#keep_connected) return;
+        this.#idle_timer = setTimeout(() => {
+            this.#idle_timer = null;
+            ssoLog("disconnecting from host tooling after inactivity");
+            this.disconnect();
+        }, Broker.IDLE_DISCONNECT_MS);
+    }
+
+    #clear_idle_timer() {
+        if (this.#idle_timer !== null) {
+            clearTimeout(this.#idle_timer);
+            this.#idle_timer = null;
+        }
+    }
+
     isConnected() {
-        return this.#port_native !== null;
+        /**
+         * As we internally manage the lifecycle of the connection,
+         * we only let the caller know if we are unable to connect to the host
+         */
+        return !this.#conn_error;
     }
 
     isRunning() {
-        return this.#online;
+        return !this.#conn_error && this.#online;
     }
 
     getAccounts() {
+        this.#keep_alive();
         this.#port_native.postMessage({ command: "getAccounts" });
         return this.#rpc_queue.register_handle("getAccounts");
     }
 
     async acquireTokenSilently(account) {
+        this.#keep_alive();
         this.#port_native.postMessage({
             command: "acquireTokenSilently",
             account: account.brokerObject(),
@@ -93,6 +150,7 @@ export class Broker {
     }
 
     async acquirePrtSsoCookie(account, ssoUrl) {
+        this.#keep_alive();
         this.#port_native.postMessage({
             command: "acquirePrtSsoCookie",
             account: account.brokerObject(),
@@ -102,6 +160,7 @@ export class Broker {
     }
 
     async getVersion() {
+        this.#keep_alive();
         this.#port_native.postMessage({ command: "getVersion" });
         return this.#rpc_queue.register_handle("getVersion");
     }

--- a/src/device.js
+++ b/src/device.js
@@ -13,6 +13,17 @@ export class Device {
         this.name = name;
         this.compliant = compliant;
     }
+
+    toSerial() {
+        return {
+            name: this.name,
+            compliant: this.compliant,
+        };
+    }
+
+    static fromSerial(serial) {
+        return new Device(serial.name, serial.compliant);
+    }
 }
 
 export class DeviceManager {
@@ -86,5 +97,27 @@ export class DeviceManager {
 
     getDevice() {
         return this.device;
+    }
+
+    /*
+     * Store the current device state in the session storage.
+     */
+    async persist() {
+        const state = {
+            last_refresh: this.#last_refresh,
+            device: this.device ? this.device.toSerial() : null,
+        };
+        return chrome.storage.session.set({ device_manager: state });
+    }
+
+    async restore() {
+        const data = await chrome.storage.session.get("device_manager");
+        if (!data.device_manager) {
+            return;
+        }
+        this.#last_refresh = data.device_manager.last_refresh ?? 0;
+        this.device = data.device_manager.device
+            ? Device.fromSerial(data.device_manager.device)
+            : null;
     }
 }

--- a/src/device.js
+++ b/src/device.js
@@ -31,6 +31,8 @@ export class DeviceManager {
 
     #am = null;
     #last_refresh = 0;
+    /* in-flight device load, to dedup concurrent calls */
+    #refresh_promise = null;
     device = null;
 
     constructor(account_manager) {
@@ -60,6 +62,19 @@ export class DeviceManager {
      * @returns true on success
      */
     async loadDeviceInfo(broker) {
+        /* coalesce concurrent loads into a single request */
+        if (this.#refresh_promise) {
+            return this.#refresh_promise;
+        }
+        this.#refresh_promise = this.#loadDeviceInfo(broker);
+        try {
+            return await this.#refresh_promise;
+        } finally {
+            this.#refresh_promise = null;
+        }
+    }
+
+    async #loadDeviceInfo(broker) {
         if (!this.#am.hasAccounts()) {
             return false;
         }

--- a/src/platform.js
+++ b/src/platform.js
@@ -8,6 +8,15 @@ import { ssoLog } from "./utils.js";
 export class Platform {
     static SSO_URL = "https://login.microsoftonline.com";
 
+    /*
+     * Whether the connection to the native messaging backend must be kept
+     * alive permanently. On platforms that rely on a running service worker
+     * (e.g. blocking webRequest), a persistent NM port prevents the MV3
+     * worker from being shut down. Platforms that use declarative mechanisms
+     * (e.g. declarativeNetRequest) can let the worker idle out.
+     */
+    static KEEP_BROKER_CONNECTED = false;
+
     browser;
 
     host_versions = {


### PR DESCRIPTION
This is a major refactoring to properly support the manifest v3 service worker lifecycle, whereby the service worker is terminated after 30 seconds of inactivity. This saves energy (by not idling the service worker) and also *should* fix issues on hibernation on Chrome (like #137).

On Firefox we unfortunately can't terminate the service worker, as this is incompatible with dynamic sets of URLs in the `webRequestBlocking` API (technically because we get the rules from a callback, but we have to register the `webRequestBlocking` handler synchronously to wakeup the service worker).

This change has been tested on both Firefox and Chromium based browsers with the (unchanged) `linux-entra-sso.py` host part. It also must be tested against the himmelblau backend.

Along these changes, it also improves the look-and-feel during browser startup, as the avatar picture is also cached.