### PR TITLE
ci: sign Chrome extension before upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions: {}
 
 env:
   WEB_EXT_VERS: 10.1.0
+  CRX3_VERS: 2.0.0
 
 jobs:
   release-extension:
@@ -55,6 +56,19 @@ jobs:
             --source-dir build/thunderbird \
             --artifacts-dir build \
             --filename '{name}-{version}.thunderbird.xpi'
+
+      # sign the Chrome extension with our own private key, as the
+      # Chrome Web Store upload requires a packed and signed CRX file
+      - name: pack signed Chrome extension
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          KEY_FILE="$(mktemp)"
+          trap 'shred -u "$KEY_FILE"' EXIT
+          printf '%s' "$CRX_PRIVATE_KEY" > "$KEY_FILE"
+          cat "build/Linux-Entra-SSO-${{ github.ref_name }}.chrome.zip" | npx crx3@${{ env.CRX3_VERS }} \
+            --key "$KEY_FILE" \
+            --crx "build/Linux-Entra-SSO-${{ github.ref_name }}.chrome.crx"
 
       - name: upload firefox extension
         uses: actions/upload-artifact@v7
@@ -131,8 +145,7 @@ jobs:
       - name: release Chrome extension on CWS
         uses: mnao305/chrome-extension-upload@fdfe79400af990f5145a319e834aee64907ccff4 # v6.0.0
         with:
-          file-path: build/Linux-Entra-SSO-*chrome.zip
-          glob: true
+          file-path: build/Linux-Entra-SSO-${{ github.ref_name }}.chrome.crx
           extension-id: jlnfnnolkbjieggibinobhkjdfbpcohn
           client-id: ${{ secrets.CWS_CLIENT_ID }}
           client-secret: ${{ secrets.CWS_CLIENT_SECRET }}


### PR DESCRIPTION
As we are getting more users of the extension, further hardenings of the release process should be applied (it's unclear if this is highly recommended for extensions with >10k users or mandatory).

To implement this, we sign the generated extension archive with a CI provided private key and upload the result to the CWS backend. There, the signature must match the configured public key and otherwise is rejected.

Unfortunately this part is basically impossible to test upfront. I deployed the key to the github action secrets and will configure the CWS part accordingly (once merged). On the next release, we will see if this works.