### PR TITLE
ci: add CODEOWNERS to let renovate assign MRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright 2026 Siemens AG
+# SPDX-License-Identifier: MPL-2.0
+*       @fmoessbauer @jan-kiszka


### PR DESCRIPTION
cc @michaeladler 