### PR TITLE
chore: configure renovate for automated updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2026 Siemens AG
+// SPDX-License-Identifier: MPL-2.0
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:best-practices",
+    "group:all",
+    "schedule:monthly",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":prHourlyLimitNone",
+    ":prConcurrentLimitNone",
+  ],
+  minimumReleaseAge: '3 days',
+  lockFileMaintenance: {
+    enabled: false,
+  },
+  assigneesFromCodeOwners: true,
+  separateMajorMinor: false,
+}


### PR DESCRIPTION
Configure Renovate to run monthly with consolidated merge requests and a 3-day minimum release age to mitigate supply-chain attack risks.
Renovate will update all dependencies it discovers, which currently consist just of the Github actions files.