### PR TITLE
ci: split release process between AMO and CWS

### DIFF
--- a/.github/workflows/release-chrome.yml
+++ b/.github/workflows/release-chrome.yml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright 2024 Siemens AG
+#
+# SPDX-License-Identifier: MPL-2.0
+
+name: release Chrome extension
+
+on:
+  push:
+    tags:
+      - 'v*.*'
+      - 'v*.*.*'
+
+permissions: {}
+
+env:
+  CRX3_VERS: 2.0.0
+
+jobs:
+  release-chrome:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y make git zip
+
+      - name: build packages
+        run: RELEASE_TAG=${{ github.ref_name }} make package
+
+      # sign the Chrome extension with our own private key, as the
+      # Chrome Web Store upload requires a packed and signed CRX file
+      - name: pack signed Chrome extension
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          KEY_FILE="$(mktemp)"
+          trap 'shred -u "$KEY_FILE"' EXIT
+          printf '%s' "$CRX_PRIVATE_KEY" > "$KEY_FILE"
+          cat "build/Linux-Entra-SSO-${{ github.ref_name }}.chrome.zip" | npx crx3@${{ env.CRX3_VERS }} \
+            --key "$KEY_FILE" \
+            --crx "build/Linux-Entra-SSO-${{ github.ref_name }}.chrome.crx"
+
+      - name: release Chrome extension on CWS
+        uses: mnao305/chrome-extension-upload@fdfe79400af990f5145a319e834aee64907ccff4 # v6.0.0
+        with:
+          file-path: build/Linux-Entra-SSO-${{ github.ref_name }}.chrome.crx
+          extension-id: jlnfnnolkbjieggibinobhkjdfbpcohn
+          client-id: ${{ secrets.CWS_CLIENT_ID }}
+          client-secret: ${{ secrets.CWS_CLIENT_SECRET }}
+          refresh-token: ${{ secrets.CWS_REFRESH_TOKEN }}
+          publish: false

--- a/.github/workflows/release-mozilla.yml
+++ b/.github/workflows/release-mozilla.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-name: release browser extension
+name: release Mozilla extensions
 
 on:
   push:
@@ -14,10 +14,9 @@ permissions: {}
 
 env:
   WEB_EXT_VERS: 10.1.0
-  CRX3_VERS: 2.0.0
 
 jobs:
-  release-extension:
+  release-mozilla:
     permissions:
       contents: write
       pull-requests: write
@@ -56,19 +55,6 @@ jobs:
             --source-dir build/thunderbird \
             --artifacts-dir build \
             --filename '{name}-{version}.thunderbird.xpi'
-
-      # sign the Chrome extension with our own private key, as the
-      # Chrome Web Store upload requires a packed and signed CRX file
-      - name: pack signed Chrome extension
-        env:
-          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
-        run: |
-          KEY_FILE="$(mktemp)"
-          trap 'shred -u "$KEY_FILE"' EXIT
-          printf '%s' "$CRX_PRIVATE_KEY" > "$KEY_FILE"
-          cat "build/Linux-Entra-SSO-${{ github.ref_name }}.chrome.zip" | npx crx3@${{ env.CRX3_VERS }} \
-            --key "$KEY_FILE" \
-            --crx "build/Linux-Entra-SSO-${{ github.ref_name }}.chrome.crx"
 
       - name: upload firefox extension
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -141,13 +127,3 @@ jobs:
           signoff: true
           body: |
             Publish update manifest for Mozilla extensions, version ${{ github.ref_name }}.
-
-      - name: release Chrome extension on CWS
-        uses: mnao305/chrome-extension-upload@fdfe79400af990f5145a319e834aee64907ccff4 # v6.0.0
-        with:
-          file-path: build/Linux-Entra-SSO-${{ github.ref_name }}.chrome.crx
-          extension-id: jlnfnnolkbjieggibinobhkjdfbpcohn
-          client-id: ${{ secrets.CWS_CLIENT_ID }}
-          client-secret: ${{ secrets.CWS_CLIENT_SECRET }}
-          refresh-token: ${{ secrets.CWS_REFRESH_TOKEN }}
-          publish: false


### PR DESCRIPTION
Both Firefox (AMO) and Chrome (CWS) require the extensions to be signed by the respective store. As this signing step can fail for various external reasons (e.g. a store is temporary not available), we must not run these steps in the same workflow. Otherwise a later failing signing step makes it impossible to be retried, as re-uploads / re-signing of existing artifacts is prohibited.

To make the workflow more robust, we split it into the Mozilla + generic part and the Chrome part.

PS: We were just bitten by this, as AMO is currently down. Luckily we can retry as the AMO step is prior to the CWS step. Otherwise the release would have been borked.