### PR TITLE
ci: put npm dependencies under renovate support

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,4 +17,27 @@
   },
   assigneesFromCodeOwners: true,
   separateMajorMinor: false,
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      matchStrings: ["WEB_EXT_VERS:\\s*(?<currentValue>\\S+)"],
+      depNameTemplate: "web-ext",
+      datasourceTemplate: "npm",
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      matchStrings: ["CRX3_VERS:\\s*(?<currentValue>\\S+)"],
+      depNameTemplate: "crx3",
+      datasourceTemplate: "npm",
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      matchStrings: ["CWS_UPLOAD_VERS:\\s*(?<currentValue>\\S+)"],
+      depNameTemplate: "chrome-webstore-upload",
+      datasourceTemplate: "npm",
+    },
+  ],
 }


### PR DESCRIPTION
Currently the components we pull via npx are not under renovate support. We now add custom managers to also track and update them.