### PR TITLE
Improve reporting of host-tooling connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,6 @@ Once granted, the application should behave as on a native install.
 
 An alternative is to use the `firefox-esr` Debian package.
 
-### Expired Tokens on Chrome
-
-Due to not having the `WebRequestsBlocking` API on Chrome, the extension needs to use a different mechanism to inject the token.
-While in Firefox the token is requested on-demand when hitting the SSO login URL, in Chrome the token is requested periodically.
-Then, a `declarativeNetRequest` API rule is setup to inject the token. As the lifetime of the tokens is limited and cannot be checked,
-outdated tokens might be injected. Further, a generic SSO URL must be used when requesting the token, instead of the actual one.
-
 ## Troubleshooting
 
 In case the extension is not working, check the following:

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Once granted, the application should behave as on a native install.
 
 An alternative is to use the `firefox-esr` Debian package.
 
+### Flatpak
+
+Browsers installed as Flatpak are not officially supported, as they run in a sandbox that isolates them from the native messaging host.
+They may work when the [`xdg-native-messaging-proxy`](https://github.com/flatpak/xdg-native-messaging-proxy)
+is used to bridge into the sandbox, but this relies on several conditions that are beyond the control of `linux-entra-sso`.
+
 ## Troubleshooting
 
 In case the extension is not working, check the following:

--- a/popup/menu.js
+++ b/popup/menu.js
@@ -88,14 +88,14 @@ bg_port.onMessage.addListener(async (m) => {
             m.broker_online ? "connected" : "disconnected";
         document.getElementById("broker-version").innerText = m.broker_version;
 
-        if (m.host_version) {
-            let pvers = chrome.runtime.getManifest().version;
-            let vstr = "v" + pvers;
-            if (m.host_version !== pvers) {
-                vstr += " (host v" + m.host_version + ")";
-            }
-            document.getElementById("version").innerText = vstr;
+        /* show the app and host version */
+        let pvers = chrome.runtime.getManifest().version;
+        let vstr = "v" + pvers;
+        if (m.host_version !== null && m.host_version !== pvers) {
+            vstr += " (host v" + m.host_version + ")";
         }
+        document.getElementById("version").innerText = vstr;
+
         if (m.device) {
             set_text_cropped(
                 document.getElementById("device-name"),

--- a/popup/menu.js
+++ b/popup/menu.js
@@ -107,6 +107,8 @@ bg_port.onMessage.addListener(async (m) => {
                 : "not compliant";
             annotate_body_if("compliant", m.device.compliant);
         }
+        annotate_by_id_if("bg-device-state", "hidden", !m.device);
+
         sso_url = m.sso_url;
         gpo = m.gpo_update;
         check_sso_provider_perms();

--- a/src/background.js
+++ b/src/background.js
@@ -187,6 +187,7 @@ function on_startup() {
         policyManager.load_policies(),
         accountManager.restore(),
         deviceManager.restore(),
+        broker.restore(),
     ]).then(() => {
         state_restored = true;
         broker.connect();

--- a/src/broker.js
+++ b/src/broker.js
@@ -46,8 +46,8 @@ export class Broker {
     #notify_fn = null;
     #port_native = null;
     #rpc_queue = new RpcHandlerQueue();
-    /* assume the broker is running until we know */
-    #online = true;
+    /* once connected to host tooling, we get the current state */
+    #online = false;
     /* track if the NM connection was successful */
     #conn_error = false;
     /* track if we ever had a successful connection to the native app */

--- a/src/broker.js
+++ b/src/broker.js
@@ -50,6 +50,8 @@ export class Broker {
     #online = true;
     /* track if the NM connection was successful */
     #conn_error = false;
+    /* track if we ever had a successful connection to the native app */
+    #had_connection = false;
     #idle_timer = null;
     /* if set, the NM connection is kept alive permanently */
     #keep_connected = false;
@@ -68,6 +70,7 @@ export class Broker {
         this.#conn_error = false;
         this.#port_native = chrome.runtime.connectNative(this.#name);
         this.#port_native.onDisconnect.addListener(() => {
+            /* note, that this is not called on .disconnect(), only on errors */
             this.#port_native = null;
             if (chrome.runtime.lastError) {
                 ssoLogError(
@@ -76,6 +79,7 @@ export class Broker {
                 );
                 this.#conn_error = true;
             } else {
+                /* Connection closed by the native application. */
                 ssoLogError("Native application connection closed.");
             }
             this.#notify_fn(false);
@@ -84,7 +88,6 @@ export class Broker {
             this.#on_message_native.bind(this),
         );
         this.#reset_idle_timer();
-        ssoLog("connected to host tooling");
     }
 
     disconnect() {
@@ -127,11 +130,26 @@ export class Broker {
          * As we internally manage the lifecycle of the connection,
          * we only let the caller know if we are unable to connect to the host
          */
-        return !this.#conn_error;
+        return !this.#conn_error && this.#had_connection;
     }
 
     isRunning() {
         return !this.#conn_error && this.#online;
+    }
+
+    /*
+     * Persist the connection tracking state in the session storage.
+     */
+    async persist() {
+        return chrome.storage.session.set({
+            broker_state: { had_connection: this.#had_connection },
+        });
+    }
+
+    async restore() {
+        const data = await chrome.storage.session.get("broker_state");
+        if (!data.broker_state) return;
+        this.#had_connection = data.broker_state.had_connection ?? false;
     }
 
     getAccounts() {
@@ -166,6 +184,13 @@ export class Broker {
     }
 
     #on_message_native(response) {
+        /* receiving any message proves the connection was successful */
+        if (!this.#had_connection) {
+            this.#had_connection = true;
+            this.persist();
+            ssoLog("connected to host tooling");
+        }
+
         /* handle events (not an RPC response) */
         if (response.command == "brokerStateChanged") {
             if (response.message == "online") this.#online = true;


### PR DESCRIPTION
As noted in #156 , we currently don't properly report the case that a connection to the host-tooling is not working. This error reporting was lost during cb31ec0, as there we intentionally disconnect from the host tooling.

Restore it and make it more robust by actually checking if we ever hat a successful response from the host tooling.