### PR TITLE
chore: let renovate prefer semver tag instead of digest updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "config:best-practices",
+    "helpers:pinGitHubActionDigestsToSemver",
     "group:all",
     "schedule:monthly",
     ":semanticCommits",


### PR DESCRIPTION
The github actions tag which just contain a version (e.g. v7) are mutable and shifted to the latest one on every update of the corresponding semversioned one (e.g. v7 is shifted once v7.0.1 is released). This results in hard to review digest-only updates, while the new digest always also corresponds to a semversioned tag.

We now configure renovate to snap to the semversioned tags in these cases.