### PR TITLE
ci: create update manifest based on main branch

### DIFF
--- a/.github/workflows/release-mozilla.yml
+++ b/.github/workflows/release-mozilla.yml
@@ -90,6 +90,11 @@ jobs:
           draft: false
           prerelease: true
 
+      - name: checkout main branch for update manifests
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
       - name: create update manifest for Firefox
         run: |
           VERSION=$(echo ${{ github.ref_name }} | cut -c 2-)


### PR DESCRIPTION
When creating a release from a rel-branch, the update manifest does not contain data of releases which happened later in time. However, as there is only a single update manifest (maintained on the main branch), we need to accumulate all release data there. For that, we checkout the main branch right before updating the update manifest when creating a release. This ensures we always append to the latest version.