### PR TITLE
forward port of the security fixes of v1.10.2

### DIFF
--- a/platform/firefox/js/platform-firefox.js
+++ b/platform/firefox/js/platform-firefox.js
@@ -54,7 +54,11 @@ export class PlatformFirefox extends Platform {
 
     async #onBeforeSendHeaders(e) {
         // filter out requests that are not part of the OAuth2.0 flow
-        if (!e.url.startsWith(Platform.SSO_URL)) {
+        const url = URL.parse(e.url);
+        if (
+            url?.protocol !== "https:" ||
+            url.origin !== URL.parse(Platform.SSO_URL).origin
+        ) {
             return { requestHeaders: e.requestHeaders };
         }
         try {

--- a/popup/menu.js
+++ b/popup/menu.js
@@ -191,7 +191,7 @@ async function check_bg_sso_enabled() {
     if (
         !tab?.url ||
         !tab.url.startsWith("https://") ||
-        tab.url.startsWith(sso_url)
+        URL.parse(tab.url)?.origin === URL.parse(sso_url).origin
     ) {
         annotate_by_id_if("bg-sso-state", "hidden", true);
         return;


### PR DESCRIPTION
This should have happened prior to the backport. A learning which is now documented via #165 .